### PR TITLE
Update CTM documentation

### DIFF
--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -25,6 +25,8 @@ This technique is documented here: [Cutting the Mustard with Media queries](http
 
 The media queries we use are based upon [CSS Only Mustard Cut](https://github.com/Fall-Back/CSS-Mustard-Cut), with a preference towards combining them into one rather than separating them out into multiple `<link>` elements.  Note that you **cannot** add line breaks to the media query if they are combined.
 
+Note that while our graded browser support table specifies Internet Explorer 10 and below as grade-c, until an updated media query is found this approach renders IE10 as grade-a.
+
 ```html
 <link rel="stylesheet" href="your-css.css" media="only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)">
 ```
@@ -45,3 +47,5 @@ In order to check this, we use [window.matchMedia](https://developer.mozilla.org
     }
 })();
 ```
+
+The javascript code outlined above will fail in Internet Explorer if there is more than one link element. You can get around this by targeting the specific link element using a class or ID.


### PR DESCRIPTION
- highlight discrepancy between our graded browser support table and CTM media query with regards to Internet Explorer 10
- point out a potential issue with the Javascript CTM check when there are multiple link elements