### PR TITLE
Removing optimize for readability section as is redundant in Javascript documentation of playbook.

### DIFF
--- a/technologies/javascript.md
+++ b/technologies/javascript.md
@@ -68,14 +68,6 @@ function loadConfigFile(filePath, callback) {
 }
 ```
 
-
-### Optimise For Reading
-
-Code is written once and read many times, using abbreviations or single-character variables saves time in the short term but there's an overhead every time somebody has to read that code.
-
-Reading code is difficult enough at the best of times. Don't make it harder; it's better to have RSI in your over-worked fingers than for all your colleagues to hate you.
-
-
 ### Modules Over Monoliths
 
 Wherever possible, you should try to think in smaller single-purpose modules and functions. This encourages reuse and helps to [keep complexity down].


### PR DESCRIPTION
Removing optimize for readability section as is redundant in Javascript documentation of playbook.