### PR TITLE
Remove reference to atomic CSS article

### DIFF
--- a/practices/css/oocss.md
+++ b/practices/css/oocss.md
@@ -38,7 +38,6 @@ As OOCSS is more of a philosophy than a prescriptive system the implementation w
 ## Find out more:
 
 * [OOCSS Wiki](https://github.com/stubbornella/oocss/wiki)
-* [Introduction to OOCSS](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/)
-* [Atomic CSS](https://www.smashingmagazine.com/2013/10/challenging-css-best-practices-atomic-approach/)
-* [BEM](http://getbem.com/introduction/)
+* [An Introduction to Object Oriented CSS (OOCSS)](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/)
+* [Introduction to Block Element Modifier (BEM)](http://getbem.com/introduction/)
 * [OOCSS at BBC Sport](https://medium.com/@shaunbent/css-at-bbc-sport-part-1-bab546184e66)

--- a/practices/house-style.md
+++ b/practices/house-style.md
@@ -15,48 +15,48 @@ This document outlines the reasons for our having a house style, and generally-a
 
 ## Rationale
 
-The benefits of choosing one house style outweigh the benefits of allowing people free rein with code style. Personal preference is outweighed by the greater good. This isn't to say that we shouldn't constantly be looking to improve our ways of working. We aim to reduce friction for ourselves as we move between teams, and we do this by maintaining a general house style, linting, and agreeing on common practices. 
+The benefits of choosing one house style outweigh the benefits of allowing people free rein with code style. Personal preference is outweighed by the greater good. This isn't to say that we shouldn't constantly be looking to improve our ways of working. We aim to reduce friction for ourselves as we move between teams, and we do this by maintaining a general house style, linting, and agreeing on common practices.
 
-Read this excellent [article by Nicholas C. Zakas](https://www.smashingmagazine.com/2012/10/why-coding-style-matters/) to understand why having a house style is important. 
+Read this excellent [article by Nicholas C. Zakas](https://www.smashingmagazine.com/2012/10/why-coding-style-matters/) to understand why having a house style is important.
 
 
 ## General principles
 
-Read the [markup guide](../technologies/markup.md), the [JavaScript guide](../technologies/javascript.md) and the [CSS guide](../technologies/css.md) to understand our house style in these technologies. You should also familiarise yourself with our [Git](git/git.md) strategies. The team you're deployed to may also have its own strategies in addition to these. 
+Read the [markup guide](../technologies/markup.md), the [JavaScript guide](../technologies/javascript.md) and the [CSS guide](../technologies/css.md) to understand our house style in these technologies. You should also familiarise yourself with our [Git](git/git.md) strategies. The team you're deployed to may also have its own strategies in addition to these.
 
 ### Linting
 
-We lint our CSS, JavaScript, and templates written with DustJS. This helps us to keep our codebases consistent, avoid common logic and implementation errors, and lets us concentrate on solving problems instead of formatting. 
+We lint our CSS, JavaScript, and templates written with DustJS. This helps us to keep our codebases consistent, avoid common logic and implementation errors, and lets us concentrate on solving problems instead of formatting.
 
 * For CSS, use [StyleLint](https://github.com/stylelint/stylelint)
 * For JavaScript, use [XO](https://github.com/sindresorhus/xo)
 * For DustJS, use [Dustmite](https://www.npmjs.com/package/dustmite)
 
-See the CSS, JavaScript, and markup guides for further details. 
+See the [CSS](../technologies/css.md), [JavaScript](../technologies/javascript.md), and [markup](../technologies/markup.md) guides for further details.
 
 ### Accessibility 
 
-We care a great deal about accessibility. We aim to comply with the [Web Content Accessibility Guidelines 1](https://www.w3.org/TR/WCAG10/) AA + the [WCAG Samurai Errata](http://www.wcagsamurai.org/erratas/introduction/). In doing so, we also achieve a high pass rate with [Web Content Accessibility Guidelines 2](https://www.w3.org/TR/WCAG20/) AA. All of our websites MUST comply with [US Section 508](https://www.section508.gov/) and [UK Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents). 
+We care a great deal about accessibility. We aim to comply with the [Web Content Accessibility Guidelines 1](https://www.w3.org/TR/WCAG10/) AA + the [WCAG Samurai Errata](http://www.wcagsamurai.org/erratas/introduction/). In doing so, we also achieve a high pass rate with [Web Content Accessibility Guidelines 2](https://www.w3.org/TR/WCAG20/) AA. All of our websites MUST comply with [US Section 508](https://www.section508.gov/) and [UK Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents).
 
-Read our [Accessibility guide](accessibility/accessibility.md) and [accessibility checklist](accessibility/accessibility-checklist.md) to understand how we meet these aims. 
+Read our [Accessibility guide](accessibility/accessibility.md) and [accessibility checklist](accessibility/accessibility-checklist.md) to understand how we meet these aims.
 
 ### Progressive enhancement and browser support
 
-We support *all* browsers to different degrees of functionality. "Support" does *not* mean that everybody gets the same thing. Read our [Graded Browser Support page](../practices/graded-browser-support.md) to understand our approach and where to aim your efforts. 
+We support *all* browsers to different degrees of functionality. "Support" does *not* mean that everybody gets the same thing. Read our [Graded Browser Support page](../practices/graded-browser-support.md) to understand our approach and where to aim your efforts.
 
-Using graded browser support means that you MUST practice progressive enhancement when building sites for Springer Nature, not graceful degradation. See the [progressive enhancement guide](../practices/progressive-enhancement.md) to understand what this means. 
+Using graded browser support means that you MUST practice progressive enhancement when building sites for Springer Nature, not graceful degradation. See the [progressive enhancement guide](../practices/progressive-enhancement.md) to understand what this means.
 
 ### Code review
 
-We practice code review to safeguard the quality of what we produce. Code review aims to catch inadvertent mistakes, errors, and omissions (e.g. missing tests), and to act as a learning exercise for reviewers and reviewees. 
+We practice code review to safeguard the quality of what we produce. Code review aims to catch inadvertent mistakes, errors, and omissions (e.g. missing tests), and to act as a learning exercise for reviewers and reviewees.
 
-Everyone is expected to review code submissions; your level of experience as a developer or with the codebase in question doesn't matter. When submitting code for review, be prepared to explain your thinking. When reviewing code, don't be afraid to ask the submitter to explain! 
+Everyone is expected to review code submissions; your level of experience as a developer or with the codebase in question doesn't matter. When submitting code for review, be prepared to explain your thinking. When reviewing code, don't be afraid to ask the submitter to explain!
 
-Read the [code review guide](../practices/code-review.md) for details on how we manage code reviews, and what to look for when reviewing. 
+Read the [code review guide](../practices/code-review.md) for details on how we manage code reviews, and what to look for when reviewing.
 
 ### Written communications
 
-Not all written communications need to follow house style - for e.g. we don't expect you to follow any rules in Slack, beyond what's expected of you as a professional. If you write for any of our open source repositories (including documentation), [Cruft.io](http://cruft.io/), or any of our [social media accounts](../practices/social-media.md), please familiarise yourself with the [Language guide](../practices/language.md). 
+Not all written communications need to follow house style - for e.g. we don't expect you to follow any rules in Slack, beyond what's expected of you as a professional. If you write for any of our open source repositories (including documentation), [Cruft.io](http://cruft.io/), or any of our [social media accounts](../practices/social-media.md), please familiarise yourself with the [Language guide](../practices/language.md).
 
 
 ## Making changes to the house style
@@ -67,5 +67,5 @@ If you would like to propose a change to house style, follow these steps:
 
 1. Read the relevant page in the playbook (assuming it exists).
 2. Understand that you SHOULD NOT deviate from this style unless there are valid reasons in particular circumstances when the particular behavior is acceptable or even useful.
-3. If you believe that your situation or case meets the criteria in point 2, detail to the rest of the team the benefits of making an exception or a change. 
+3. If you believe that your situation or case meets the criteria in point 2, detail to the rest of the team the benefits of making an exception or a change.
 4. If the team agrees that your exeption (or change) is acceptable and useful, submit a PR to the playbook, detailing the exception (or change) to the world.


### PR DESCRIPTION
* Remove ref to atomic CSS article.
* Rename links.
* Add inline links for clarity.
* Whitespace cleanup