### PR TITLE
Make headings sentence case

### DIFF
--- a/practices/code-review.md
+++ b/practices/code-review.md
@@ -1,4 +1,4 @@
-# Code Reviews
+# Code reviews
 
 * [Why](#why)
 * [How](#how)

--- a/practices/css/bem-css.md
+++ b/practices/css/bem-css.md
@@ -16,7 +16,7 @@ BEM naming follows this pattern:
 .block--modifier {}
 ```
 
-## Naming Style
+## Naming style
 
 All class names should be _lowercase-hyphenated_ - all lowercase, words separated by a hyphen.
 
@@ -57,7 +57,7 @@ We do this:
 - `.alert-box--success`
 - `.button--expanded`
 
-## BEM Best practices
+## BEM best practices
 
 Don't `@extend` block modifiers with the block base, always require that the base/unmodified class is present
 

--- a/practices/css/mosaic-css.md
+++ b/practices/css/mosaic-css.md
@@ -122,11 +122,11 @@ Notice that following the rules of separating structure and skin, we are only in
 
 Common styles and patterns can then be reused across projects, and for Nature content displayed in the mosaic style, our common shared CSS can be found in [shunter-mosaic (private repo)](https://github.com/stubbornella/oocss/wiki/FAQ). We can then build on top of this within each project to add styles and patterns that are specific to that project.
 
-### Class Names
+### Class names
 
 Traditionally we have always been told to use semantic class names, that they should reflect the intended structure or meaning of the element it is applied to, as oppose to the presentation. However, this idea has been [debunked as a fallacy](http://nicolasgallagher.com/about-html-semantics-front-end-architecture/), as classes aren’t understood by machines (with microformats being a notable exception). Rather than worrying about creating semantic class names, we should be thinking about creating _sensible_ class names that offer flexibility and reusability. They should give meaning to an element to make it easier to understand and maintain for _developers_. We can do this by naming them based on their function (role) or based on their form (visual).
 
-#### Functional Class Names
+#### Functional class names
 Use functional class names when the styling is based on their function or meaning. There is a strong connection between the class name, the styles it applies, and the reason the styles are being applied. Functional class names will always be used to describe OOCSS objects, as these are styles grouped together to carry out a particular function, and also for positioning utility classes. Some examples include:
 
 ```css
@@ -139,7 +139,7 @@ Use functional class names when the styling is based on their function or meanin
 .position-absolute {} /*  positioning utility class */
 ```
 
-#### Presentational Class Names
+#### Presentational class names
 Presentational class names describe the way an element looks. The name itself is describing the styles that are being applied. These classes are conducive to code reuse as they don't care what they are being used to style. This also comes with the benefit of scaling gracefully. As you're developing new components, you just need to add existing styles to your markup. Soon you will find that creating a new component requires no new CSS to be written, you are just applying existing styles to your HTML. Presentation class names are used for utility styling classes. Some examples include:
 
 ```css
@@ -154,15 +154,15 @@ Presentational class names describe the way an element looks. The name itself is
 .padding10 {}
 ```
 
-#### Naming Convention
+#### Naming convention
 
 All class names should be _lowercase-hyphenated_ - all lowercase, words separated by a hyphen. So ```.object-name``` and not ```.objectName``` or ```.ObjectName``` or ```.Object-Name```.
 
-### The Classitis Tradeoff
+### The classitis tradeoff
 
 One of the downsides of this approach is the bloating of the HTML with classes. Separating structure from skin and container from content results in more classes on elements than traditional methods. In the end it comes down to whether you would rather have DRY CSS or DRY HTML, and we came to the conclusion that DRY CSS using the object oriented methodology is preferable due to its maintainability - it may be easier to add/remove classes in your html when updating a component than it is to rewrite your CSS when something changes. On large sites the OOCSS approach produces significantly less CSS making it easier to maintain and adapt to change.
 
-### Font Sizing
+### Font sizing
 
 All font sizes MUST be specified using rems only with a pixel fall back. Do not use percentages, ems or pixels alone. When using Shunter the px fallback is added automatically. In order for rems to be easily calculated you should have the following in your css:
 
@@ -178,7 +178,7 @@ body {
 
 The font size on the html element resets the base font size to ```10px```, allowing the rem value to be the pixel value divided by 10 - so ```11px``` would be ```1.1rem```. The use of ```font-size: 1.7em``` on the body fixes a [rems bug in chrome].
 
-### Javascript Hooks
+### Javascript hooks
 
 Using some form of JavaScript-specific classes can help to reduce the risk that changes to components will break any JavaScript that is also applied. We used to take the approach of using certain classes only for JavaScript hooks – ```js-*``` – and not to hang any presentation off them. This has been dropped in favour of using Data Attributes.
 

--- a/practices/css/oocss.md
+++ b/practices/css/oocss.md
@@ -1,4 +1,4 @@
-# Object Oriented CSS
+# Object oriented CSS
 
 * [What is OOCSS](#what-is-oocss)
 * [Why we use OOCSS](#why-we-use-oocss)

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -1,4 +1,4 @@
-# Graded Browser Support
+# Graded browser support
 
 * [Our criteria for browser support](#our-criteria-for-browser-support)
 * [How we implement graded browser support](#how-we-implement-graded-browser-support)

--- a/practices/house-style.md
+++ b/practices/house-style.md
@@ -1,5 +1,5 @@
-House Style Guide
-======================
+House style guide
+=================
 
 This document outlines the reasons for our having a house style, and generally-applicable principles. It's a living styleguide – it will grow as our practices do.
 
@@ -42,7 +42,7 @@ Read our [Accessibility guide](accessibility/accessibility.md) and [accessibilit
 
 ### Progressive enhancement and browser support
 
-We support *all* browsers to different degrees of functionality. "Support" does *not* mean that everybody gets the same thing. Read our [Graded Browser Support page](../practices/graded-browser-support.md) to understand our approach and where to aim your efforts.
+We support *all* browsers to different degrees of functionality. "Support" does *not* mean that everybody gets the same thing. Read our [graded browser support page](../practices/graded-browser-support.md) to understand our approach and where to aim your efforts.
 
 Using graded browser support means that you MUST practice progressive enhancement when building sites for Springer Nature, not graceful degradation. See the [progressive enhancement guide](../practices/progressive-enhancement.md) to understand what this means.
 

--- a/practices/progressive-enhancement.md
+++ b/practices/progressive-enhancement.md
@@ -1,4 +1,4 @@
-# Progressive Enhancement
+# Progressive enhancement
 
 * [What is progressive enhancement](#what-is-progressive-enhancement)
 * [Why we use progressive enhancement](#why-we-use-progressive-enhancement)
@@ -6,13 +6,13 @@
   * [Why do we care about those crusty old browsers? I'm building a ✨Web App✨, not a web page!](#why-do-we-care-about-those-crusty-old-browsers-im-building-a-✨web-app✨-not-a-web-page)
 * [Find out more:](#find-out-more)
 
-## What is progressive enhancement
+## What is it?
 
 Progressive enhancement is a design and development practice that focuses on delivering the basic essentials of a website as a primary concern, then building the various layers of refinement and niceties on top of that for those clients than can receive them. In practice this means that we start with developing a logical and semantic HTML application with all the key functionality, then we can enhance this with an aesthetic layer (CSS) and behavioural layer (JavaScript) as desired.
 
 There is a subtle but important difference in this approach vs the outdated approach of "graceful degradation" (or fault-tolerance) which it can often be confused with. Graceful degradation suggests a feature-complete "full-fat" application is designed and built, and is expected to be delivered wholesale to each client. Developers then attempt to build into the system fail safes so that when a client is unable to use the whole application, it can still get some value out of it.
 
-## Why we use progressive enhancement
+## Why we use it
 
 There are several key benefits to using progressive enhancement;
 

--- a/technologies/css.md
+++ b/technologies/css.md
@@ -1,4 +1,4 @@
-# CSS Style Guide
+# CSS style guide
 
 This document aspires to outline the way we write CSS/SASS, and is based at the moment on the existing [Nature playbook (Private repo)](https://github.com/springernature/playbook). This is just a first pass, and is likely to be incomplete (and wrong) in places.  It's a living styleguide – it will grow and adapt as our practices do.
 
@@ -24,7 +24,7 @@ Projects should use [StyleLint](https://github.com/stylelint/stylelint) to enfor
   - [General](#general)
   - [Single Line CSS](#single-line-css)
 
-## General Principles
+## General principles
 
 We write our CSS using design patterns that aim to maximise maintainability and reuse;
 
@@ -33,7 +33,7 @@ We write our CSS using design patterns that aim to maximise maintainability and 
 
 See our [house style document](../practices/house-style.md) to understand the rationale behind enforcement of style.
 
-## Code Style
+## Code style
 
 Avoid using HTML tags in CSS selectors. And always prefer using a class over HTML tags (with some exceptions)
 
@@ -104,7 +104,7 @@ We do this:
 
 Don't use `!important`. If you must, leave a comment, and prioritise resolving specificity issues before resorting to `!important`.
 
-## Preprocessors
+## Preprocessorså
 
 Our preferred CSS preprocessor is [SASS](http://sass-lang.com/) using the [SCSS syntax](http://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html).
 
@@ -435,7 +435,7 @@ a {
 }
 ```
 
-### Media Features
+### Media features
 
 There MUST be a single space after the colon.  
 There MUST NOT be whitespace before the colon.  
@@ -616,7 +616,7 @@ a,
 b { color: pink; }
 ```
 
-### Value Lists
+### Value lists
 
 There MUST be a newline after the commas in multi-line value lists.  
 There MUST be a single space after the commas in single-line value lists.  
@@ -686,7 +686,7 @@ a { color: pink; }
  * This newline */
 ```
 
-### Single Line CSS
+### Single line CSS
 
 A quick note on single line CSS. We allow single line CSS when there is only one declaration, but we shouldn't always use it. We only ever use single line CSS when there are groups of multiple CSS classes with one declaration, for example spacing, to aid legibility. In this case we also do not require a space between classes. So we would use it in the following example:
 

--- a/technologies/javascript.md
+++ b/technologies/javascript.md
@@ -1,4 +1,4 @@
-# JavaScript Style Guide
+# JavaScript style guide
 
 This document outlines the way we write JavaScript. It's a living styleguide – it will grow as our practices do.
 
@@ -29,9 +29,9 @@ This document outlines the way we write JavaScript. It's a living styleguide –
     - [Vendor Directory](#vendor-directory)
     - [Utils Directory](#utils-directory)
 
-## General Principles
+## General principles
 
-### Code For Humans
+### Code for humans
 
 Your JavaScript should always be optimised for readability first, as someone is going to have to maintain your code. Most of the rules in this style guide are here to help enforce this. See our [house style document](../practices/house-style.md) to understand the rationale behind enforcement of style. 
 
@@ -62,7 +62,7 @@ function loadConfigFile(filePath, callback) {
 }
 ```
 
-### Modules Over Monoliths
+### Modules over monoliths
 
 Wherever possible, you should try to think in smaller single-purpose modules and functions. This encourages reuse and helps to [keep complexity down](https://en.wikipedia.org/wiki/Cyclomatic_complexity).
 
@@ -107,7 +107,7 @@ foo = bar;
 bar = tempVar;
 ```
 
-### Performant Code
+### Performant code
 
 We should always try to write fast code, but not if it makes the code difficult to understand. It's inefficient to optimise in favour of performance unless evidence shows that you really _need_ to do that.
 
@@ -154,7 +154,7 @@ const object = {
 };
 ```
 
-#### Questions and Answers
+#### Questions and answers
 
 Q: XO is complaining about the following code:
 
@@ -334,13 +334,13 @@ if (foo) {
 
 We use automated tools (like Snyk) to monitor the status of dependencies in our package.json files. The majority of these tools expect two spaces for indentation, not tabs. Follow this convention in your package.json files to avoid irritating merges when one of the tools raises an automatic Pull Request. 
 
-### White Space
+### White space
 
 We use white space liberally to help keep code readable. You're encouraged to use newlines to break up long functions into logical chunks.
 
 You should also remove trailing white space from lines of code. Your editor should be able to either remove this or highlight it when present, for example, [atom-whitespace](https://github.com/atom/whitespace).
 
-### Semi-Colons
+### Semi-colons
 
 We require the use of semi-colons. The only statements that don't need to end with semi-colons are function declarations and blocks.
 
@@ -464,7 +464,7 @@ var loadConfig = function (filePaths, callback) {
 function loadConfig(filePaths, callback){ /* ... */ }
 ```
 
-#### Pure Functions
+#### Pure functions
 
 Where possible, keep your [JavaScript functions pure](http://alistapart.com/article/making-your-javascript-pure).
 
@@ -662,7 +662,7 @@ for (const prop in obj) {
 }
 ```
 
-#### Error Handling
+#### Error handling
 
 `try/catch` blocks must be indented in the same way as conditionals, with `catch` starting on the same line as the end curly brace of the `try`.
 
@@ -690,7 +690,7 @@ try { foo += 1; }
 catch (error) { console.log(error); }
 ```
 
-### Strict Mode
+### Strict mode
 
 You should assume that your code will fail, and take steps to handle those failures.
 
@@ -700,11 +700,11 @@ In Node.js, you can add `'use strict';` to the top of each of your source files.
 
 In-browser you should not add your `'use strict';` to the top of the file; instead you should add it to either the file's [IIFE](http://benalman.com/news/2010/11/immediately-invoked-function-expression/) or each defined function if an IIFE isn't present. This is because global strict mode in browsers can cause issues with third-party code.
 
-Client-Side JavaScript Architecture
+Client-side JavaScript architecture
 -----------------------------------
 
 
-### Directory Structure
+### Directory structure
 
 Client-Side JavaScript normally lives in `resources/js` in our projects, unless the back-end you're using dictates a different directory.  We should try to stick as closely to this as possible though.
 
@@ -720,7 +720,7 @@ Within this directory, you should always use the following structure. We'll go i
 
 File names in these directories should be lower-case, with words separated by dashes.
 
-#### Components Directory
+#### Components directory
 
 The `components` directory is used to house JavaScript that couples to the DOM. There are several conditions that need to be met for a file to live in here:
 
@@ -730,7 +730,7 @@ The `components` directory is used to house JavaScript that couples to the DOM. 
 
 An example component might be an auto-complete, tab group, or loading spinner.
 
-#### Polyfills Directory
+#### Polyfills directory
 
 The `polyfills` directory contains JavaScript that polyfills browser behaviour for older clients. JavaScript in this directory must meet these conditions:
 
@@ -740,7 +740,7 @@ The `polyfills` directory contains JavaScript that polyfills browser behaviour f
 
 An example polyfill might add `requestAnimationFrame` for any grade-A browsers which don't support it.
 
-#### Vendor Directory
+#### Vendor directory
 
 The `vendor` directory is where third-party code lives. It's also where we add code which is written in-house but managed and versioned elsewhere, e.g. as an open source project.
 
@@ -755,7 +755,7 @@ JavaScript in this directory must meet these conditions:
 
 An example vendor library might be jQuery, which would live in a file named `jquery-2.1.4.js`.
 
-#### Utils Directory
+#### Utils directory
 
 The `utils` directory is used to house JavaScript written for the project that doesn't fit into the rules for the `components` directory. Utilities still have some conditions of their own:
 


### PR DESCRIPTION
This PR standardises the case of headings which were previously a mix of sentence case and word case.  I've chosen sentence case, which was the case used in the root's README, so `Some Heading` has become `Some heading`, hopefully everywhere.  But say if you have a preference for another case.