### PR TITLE
Update the graded browser support table

### DIFF
--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -17,9 +17,9 @@ Our browser support in summary:
 
 | Tables                      | Grade-A support                 | Grade-C support    |
 | --------------------------- |:-------------------------------:| ------------------:|
-| Chrome                      | latest stable                   | < 29               |
-| Edge                        | latest stable                   | < latest stable -1 |
-| Firefox                     | latest stable                   | < 28               |
+| Chrome                      | latest stable, latest stable -1 | < 29               |
+| Edge                        | latest stable, latest stable -1 | < latest stable -1 |
+| Firefox                     | latest stable, latest stable -1 | < 28               |
 | IE                          | 10                              | < 10               |
 | Opera                       | latest stable                   | < 12.1             |
 | Safari iOS                  | latest stable, latest stable -1 | < 7                |

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -13,14 +13,14 @@ Our browser support in summary:
 
 - Grade-A are browser versions that are explicitly *supported*. A product bug in one of these browsers is a high priority.
 - Grade-C are browser versions that are explicitly *_not_ supported*. We serve only the minimum styling and functionality to these browsers. 
-- Grade-X are the grey area between Grade-A and Grade-C. We serve them the same code as Grade-A, but we do not test our products against these browser versions. Over time, analysis of errors and usage patterns may cause some browsers in Grade X to be deliberately demoted to Grade C. 
+- Grade-X are the grey area between Grade-A and Grade-C. We serve them the same code as Grade-A, but we do not test our products against these browser versions. Over time, analysis of errors and usage patterns may cause some browsers in Grade-X to be deliberately demoted to Grade-C. 
 
 | Tables                      | Grade-A support                 | Grade-C support    |
 | --------------------------- |:-------------------------------:| ------------------:|
 | Chrome                      | latest stable, latest stable -1 | < 29               |
 | Edge                        | latest stable, latest stable -1 | n/a                |
 | Firefox                     | latest stable, latest stable -1 | < 29               |
-| IE                          | 10 + 11                         | < 10               |
+| IE                          | 11                              | < 11               |
 | Opera                       | latest stable                   | < 16               |
 | Safari iOS                  | latest stable, latest stable -1 | < 7                |
 | Safari MacOS                | latest stable, latest stable -1 | < 6.1              |
@@ -28,8 +28,8 @@ Our browser support in summary:
 
 ### Notes
 
-- Edge has no explicit Grade-C support.
-- IE has no Grade-X support.
+- We have no no explicit Grade-C support for Edge.
+- We have no Grade-X support for IE, as we officially only support IE11, with anything below that being Grade-C. However, due to browser technical limitations we can only detect IE10+, so IE10 is, for now, included in our CTM media query. 
 
 ## How we implement graded browser support
 

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -19,7 +19,7 @@ Our browser support in summary:
 | --------------------------- |:-------------------------------:| ------------------:|
 | Chrome                      | latest stable, latest stable -1 | < 29               |
 | Edge                        | latest stable, latest stable -1 | < latest stable -1 |
-| Firefox                     | latest stable, latest stable -1 | < 28               |
+| Firefox                     | latest stable, latest stable -1 | < 29               |
 | IE                          | 10                              | < 10               |
 | Opera                       | latest stable                   | < 16               |
 | Safari iOS                  | latest stable, latest stable -1 | < 7                |

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -18,13 +18,18 @@ Our browser support in summary:
 | Tables                      | Grade-A support                 | Grade-C support    |
 | --------------------------- |:-------------------------------:| ------------------:|
 | Chrome                      | latest stable, latest stable -1 | < 29               |
-| Edge                        | latest stable, latest stable -1 | < latest stable -1 |
+| Edge                        | latest stable, latest stable -1 | n/a                |
 | Firefox                     | latest stable, latest stable -1 | < 29               |
-| IE                          | 10                              | < 10               |
+| IE                          | 10 + 11                         | < 10               |
 | Opera                       | latest stable                   | < 16               |
 | Safari iOS                  | latest stable, latest stable -1 | < 7                |
 | Safari MacOS                | latest stable, latest stable -1 | < 6.1              |
 | Android browser (Chromium)  | Latest stable                   | < 4.4              |
+
+### Notes
+
+- Edge has no explicit Grade-C support.
+- IE has no Grade-X support.
 
 ## How we implement graded browser support
 

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -41,7 +41,7 @@ This technique is documented here: [Cutting the Mustard with Media queries](http
 
 The media queries we use are based upon [CSS Only Mustard Cut](https://github.com/Fall-Back/CSS-Mustard-Cut), with a preference towards combining them into one rather than separating them out into multiple `<link>` elements.  Note that you **cannot** add line breaks to the media query if they are combined.
 
-Note that while our graded browser support table specifies Internet Explorer 10 and below as grade-c, until an updated media query is found this approach renders IE10 as grade-A.
+Note: As mentioned above, while our graded browser support table specifies Internet Explorer 10 and below as Grade-C, until an updated media query is found this approach will render IE10 as Grade-A.
 
 ```html
 <link rel="stylesheet" href="your-css.css" media="only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)">

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -21,7 +21,7 @@ Our browser support in summary:
 | Edge                        | latest stable, latest stable -1 | < latest stable -1 |
 | Firefox                     | latest stable, latest stable -1 | < 28               |
 | IE                          | 10                              | < 10               |
-| Opera                       | latest stable                   | < 12.1             |
+| Opera                       | latest stable                   | < 16               |
 | Safari iOS                  | latest stable, latest stable -1 | < 7                |
 | Safari MacOS                | latest stable, latest stable -1 | < 6.1              |
 | Android browser (Chromium)  | Latest stable                   | < 4.4              |

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -9,27 +9,34 @@
 We follow the guidelines for graded browser support outlined by Nate Koechley at Yahoo:
 [Yahoo Grade Browser Support guide](https://github.com/yui/yui3/wiki/Graded-Browser-Support)
 
-| Tables        | Grade-A support                 | Grade-C support |
-| ------------- |:-------------------------------:| ---------------:|
-| Chrome        | latest stable                   |                 |
-| Edge          | latest stable                   |                 |
-| Firefox       | latest stable                   |              <2 |
-| IE            | 11                              |             <11 |
-| Opera         | latest stable                   |             <10 |
-| Safari        | latest stable, latest stable -1 |  <4.1 (desktop) |
-| Webkit        | Android 4.&#8224;               |              <3 |
+Our browser support in summary:
+
+- Grade-A are browser versions that are explicitly *supported*. A product bug in one of these browsers is a high priority.
+- Grade-C are browser versions that are explicitly *_not_ supported*. We serve only the minimum styling and functionality to these browsers. 
+- Grade-X are the grey area between Grade-A and Grade-C. We serve them the same code as Grade-A, but we do not test our products against these browser versions. Over time, analysis of errors and usage patterns may cause some browsers in Grade X to be deliberately demoted to Grade C. 
+
+| Tables                      | Grade-A support                 | Grade-C support    |
+| --------------------------- |:-------------------------------:| ------------------:|
+| Chrome                      | latest stable                   | < 29               |
+| Edge                        | latest stable                   | < latest stable -1 |
+| Firefox                     | latest stable                   | < 28               |
+| IE                          | 10                              | < 10               |
+| Opera                       | latest stable                   | < 12.1             |
+| Safari iOS                  | latest stable, latest stable -1 | < 7                |
+| Safari MacOS                | latest stable, latest stable -1 | < 6.1              |
+| Android browser (Chromium)  | Latest stable                   | < 4.4              |
 
 ## How we implement graded browser support
 
 Our primary approach to graded browser support is the "cutting the mustard" progressive enhancement technique, based upon the principles developed by the BBC: [Cutting the Mustard](http://responsivenews.co.uk/post/18948466399/cutting-the-mustard).  However, user agent sniffing is still applied on some legacy projects.
 
 We load a basic stylesheet to all users. This contains only [normalisation](https://necolas.github.io/normalize.css/) and a few small enhancements to the user-agent stylesheet.
-To load the full experience only in modern browsers we implement logic in the media attribute of the `<link>` element that identifies the main stylesheet, loading the stylesheet only in browsers that recognise the properties of that media query.
+To load the full experience only in modern browsers (grade-A and grade-X) we implement logic in the media attribute of the `<link>` element that identifies the main stylesheet, loading the stylesheet only in browsers that recognise the properties of that media query.
 This technique is documented here: [Cutting the Mustard with Media queries](https://www.sitepoint.com/cutting-the-mustard-with-css-media-queries/).
 
 The media queries we use are based upon [CSS Only Mustard Cut](https://github.com/Fall-Back/CSS-Mustard-Cut), with a preference towards combining them into one rather than separating them out into multiple `<link>` elements.  Note that you **cannot** add line breaks to the media query if they are combined.
 
-Note that while our graded browser support table specifies Internet Explorer 10 and below as grade-c, until an updated media query is found this approach renders IE10 as grade-a.
+Note that while our graded browser support table specifies Internet Explorer 10 and below as grade-c, until an updated media query is found this approach renders IE10 as grade-A.
 
 ```html
 <link rel="stylesheet" href="your-css.css" media="only screen and (-webkit-min-device-pixel-ratio:0) and (min-color-index:0), (-ms-high-contrast: none), only all and (min--moz-device-pixel-ratio:0) and (min-resolution: 3e1dpcm)">


### PR DESCRIPTION
This PR will:
- Update the Graded Browser Support table to reflect our current Cutting the Mustard state.
- Add a simple definition of the Graded Browser Support levels. 

Notes:
- I've emphasised the realities of our current CTM media query (which cannot detect IE11). Until we find a way to do that, we _de facto_ support IE 10.
- The Grade C browser versions are from [here](https://github.com/Fall-Back/CSS-Mustard-Cut).
- I've added "latest stable -1" to Chrome, Edge and Firefox, to reflect the fact that even on evergreen browsers, users do not upgrade immediately. 
- We should update https://hive.springernature.com/docs/DOC-32855 if this PR is merged.

![](https://media1.giphy.com/media/eaOL2QPdY2DeM/giphy.gif)