### PR TITLE
adjust language section to cover technical writing

### DIFF
--- a/writing/language.md
+++ b/writing/language.md
@@ -8,7 +8,7 @@
     * [Unacceptable language](#unacceptable-language)
     * [Examples](#examples)
         * [Genderless language](#genderless-language)
-        * [_Bro_ language](#_bro_-language)
+        * [_Bro_ language](#bro_-language)
     * [Disability and accessibility](#disability-and-accessibility)
 * [Frontend or front-end](#frontend-or-front-end)
 
@@ -121,18 +121,18 @@ Use positive language that emphasises abilities rather than limitations. Conside
 
 We _don't_ say this:
 
-> The disabled.
-> Dyslexics.
-> Susan is a victim of blindness.
-> People suffering from deafness.
-> Users who cannot see a screen.
+> The disabled.  
+> Dyslexics.  
+> Susan is a victim of blindness.  
+> People suffering from deafness.  
+> Users who cannot see a screen.  
 
 We say this:
 
-> Disabled people.
-> Dyslexic people.
-> Susan is blind.
-> Deaf people.
+> Disabled people.  
+> Dyslexic people.  
+> Susan is blind.  
+> Deaf people.  
 > Screenreader users / blind users. [where relevant]
 
 The Special Interest Group on Accessible Computing (SIGACCESS) has published a [comprehensive guide to writing about disability](http://www.sigaccess.org/welcome-to-sigaccess/resources/accessible-writing-guide/) within the context of science and technology.

--- a/writing/language.md
+++ b/writing/language.md
@@ -1,102 +1,15 @@
 # Language
 
-* [Unacceptable language](#unacceptable-language)
-* [Examples](#examples)
-    * [Genderless language](#genderless-language)
-    * [_Bro_ language](#_bro_-language)
-* [Disability and accessibility](#disability-and-accessibility)
 * [Writing style](#writing-style)
     * [Tone of Voice](#tone-of-voice)
     * [Plain English](#plain-english)
+* [Non-discriminatory language](#non-discriminatory-language)
+    * [Unacceptable language](#unacceptable-language)
+    * [Examples](#examples)
+        * [Genderless language](#genderless-language)
+        * [_Bro_ language](#_bro_-language)
+    * [Disability and accessibility](#disability-and-accessibility)
 * [Frontend or front-end](#frontend-or-front-end)
-
-
-[Discrimination](https://en.wikipedia.org/wiki/Discrimination) is prohibited under law in the UK and many other countries.
-
-Language is our main form of communication and it plays a powerful role both in contributing to and in eliminating discrimination.
-
-Language influences thinking. For example, Hebrew uses gender markers, whereas Finnish doesn’t mark gender at all. A study done in the 1980s<sup>[\[1\]][wiley]</sup> found that kids who spoke Hebrew knew their own genders a year earlier than those who grew up speaking Finnish.
-
-Inclusive language is language that is free from words, phrases or tones that reflect prejudiced, stereotyped or discriminatory views of particular people or groups. It is also language that doesn't deliberately or inadvertently exclude people from being seen as part of a group<sup>[\[2\]][govau]</sup>.
-
-We are commited to use inclusive, non-discriminatory language in every written or verbal communication.
-
-
-## Unacceptable language
-
-Inappropriate or unacceptable language highlights perceived or actual differences between people. The use of insensitive and inappropriate language can create a hostile environment for people who have protected characteristics, as outlined in the [Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents).
-
-Stereotyping means presuming a range of things about people based on one or two of their personal characteristics such as their appearance, apparent intelligence, personality or character, or their gender, sexual orientation, race, ethnicity, age, location, socioeconomic status or disability. We don't use language that reinforces stereotypes.
-
-
-## Examples
-
-### Genderless language
-
-* We prefer to recast sentences as plural to avoid both the sexist and antiquated universal default to male pronouns and the awkward use of _he_ or _she_, _him_ or _her_ and the like:
-
-Bad:
-> Each student must complete his or her homework.
-
-Good:
-> All students must complete their homework
-
-When such a rewrite is impossible, we prefer to use the singular _they_. We also use _they_ as the genderless pronoun, in references to people who identify as neither male nor female.
-
-This mirrors the guidelines introduced by the Washington Post<sup>[\[3\]][post]</sup>.
-
-
-### _Bro_ language
-
-* We avoid examples that use _bro_ and _manly_ language, even when using verbal communication.
-
-Bad:
-> Server: Hello.
->
-> Client: Hey _bro_, I have a message for you.
-
-Good:
-> Server: Hello.
->
-> Client: Hey server, I have a message for you.
-
-Bad:
-> Hey guys!
-
-Good:
-> Hey people!
-> Hey team!
-
-
-## Disability and accessibility
-
-Using inclusive language is critical when writing about accessibility. Avoid references that dehumanise or 'other' people, or that cast them as helpless victims. Never use collective nouns like "the disabled" or "the blind" - these words are descriptors, not group labels.
-
-Use positive language that emphasises abilities rather than limitations. Consider whether you need to refer to a disability at all - for example, instead of writing about "users who are unable to use a mouse", perhaps you can be more precise with "keyboard users", or "users of alternative input devices".
-
-We _don't_ say this:
-
-```
-The disabled.
-Dyslexics.
-Susan is a victim of blindness.
-People suffering from deafness.
-Users who cannot see a screen.
-```
-
-We say this:
-
-```
-Disabled people.
-Dyslexic people.
-Susan is blind.
-Deaf people.
-Screenreader users / blind users. [where relevant]
-```
-
-The Special Interest Group on Accessible Computing (SIGACCESS) has published a [comprehensive guide to writing about disability](http://www.sigaccess.org/welcome-to-sigaccess/resources/accessible-writing-guide/) within the context of science and technology.
-
-You may also find the more general [gov.uk inclusive language guidance](https://www.gov.uk/government/publications/inclusive-communication/inclusive-language-words-to-use-and-avoid-when-writing-about-disability) helpful.
 
 
 ## Writing style
@@ -129,6 +42,91 @@ Follow Plain English guidelines to help safeguard the accessibility of your writ
 - Be informative
   - Consider your audience. General information may not look the same as information aimed at a technical audience.
   - Be as precise as you can usefully be - consider linking to high quality external resources where relevant.
+
+
+## Non-discriminatory language
+
+[Discrimination](https://en.wikipedia.org/wiki/Discrimination) is prohibited under law in the UK and many other countries.
+
+Language is our main form of communication and it plays a powerful role both in contributing to and in eliminating discrimination.
+
+Language influences thinking. For example, Hebrew uses gender markers, whereas Finnish doesn’t mark gender at all. A study done in the 1980s<sup>[\[1\]][wiley]</sup> found that kids who spoke Hebrew knew their own genders a year earlier than those who grew up speaking Finnish.
+
+Inclusive language is language that is free from words, phrases or tones that reflect prejudiced, stereotyped or discriminatory views of particular people or groups. It is also language that doesn't deliberately or inadvertently exclude people from being seen as part of a group<sup>[\[2\]][govau]</sup>.
+
+We are commited to use inclusive, non-discriminatory language in every written or verbal communication.
+
+### Unacceptable language
+
+Inappropriate or unacceptable language highlights perceived or actual differences between people. The use of insensitive and inappropriate language can create a hostile environment for people who have protected characteristics, as outlined in the [Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents).
+
+Stereotyping means presuming a range of things about people based on one or two of their personal characteristics such as their appearance, apparent intelligence, personality or character, or their gender, sexual orientation, race, ethnicity, age, location, socioeconomic status or disability. We don't use language that reinforces stereotypes.
+
+
+### Examples
+
+#### Genderless language
+
+* We prefer to recast sentences as plural to avoid both the sexist and antiquated universal default to male pronouns and the awkward use of _he_ or _she_, _him_ or _her_ and the like:
+
+We _don't_ say this:
+> Each student must complete his or her homework.
+
+We say this:
+> All students must complete their homework
+
+When such a rewrite is impossible, we prefer to use the singular _they_. We also use _they_ as the genderless pronoun, in references to people who identify as neither male nor female.
+
+This mirrors the guidelines introduced by the Washington Post<sup>[\[3\]][post]</sup>.
+
+
+#### _Bro_ language
+
+* We avoid examples that use _bro_ and _manly_ language, even when using verbal communication.
+
+We _don't_ say this:
+> Server: Hello.
+>
+> Client: Hey _bro_, I have a message for you.
+
+We say this:
+> Server: Hello.
+>
+> Client: Hey server, I have a message for you.
+
+We _don't_ say this:
+> Hey guys!
+
+We say this:
+> Hey people!
+> Hey team!
+
+
+### Disability and accessibility
+
+Using inclusive language is critical when writing about accessibility. Avoid references that dehumanise or 'other' people, or that cast them as helpless victims. Never use collective nouns like "the disabled" or "the blind" - these words are descriptors, not group labels.
+
+Use positive language that emphasises abilities rather than limitations. Consider whether you need to refer to a disability at all - for example, instead of writing about "users who are unable to use a mouse", perhaps you can be more precise with "keyboard users", or "users of alternative input devices".
+
+We _don't_ say this:
+
+> The disabled.
+> Dyslexics.
+> Susan is a victim of blindness.
+> People suffering from deafness.
+> Users who cannot see a screen.
+
+We say this:
+
+> Disabled people.
+> Dyslexic people.
+> Susan is blind.
+> Deaf people.
+> Screenreader users / blind users. [where relevant]
+
+The Special Interest Group on Accessible Computing (SIGACCESS) has published a [comprehensive guide to writing about disability](http://www.sigaccess.org/welcome-to-sigaccess/resources/accessible-writing-guide/) within the context of science and technology.
+
+You may also find the more general [gov.uk inclusive language guidance](https://www.gov.uk/government/publications/inclusive-communication/inclusive-language-words-to-use-and-avoid-when-writing-about-disability) helpful.
 
 
 ## Frontend or front-end

--- a/writing/language.md
+++ b/writing/language.md
@@ -8,7 +8,7 @@
     * [Unacceptable language](#unacceptable-language)
     * [Examples](#examples)
         * [Genderless language](#genderless-language)
-        * [_Bro_ language](#bro_-language)
+        * [_Bro_ language](#bro-language)
     * [Disability and accessibility](#disability-and-accessibility)
 * [Frontend or front-end](#frontend-or-front-end)
 

--- a/writing/language.md
+++ b/writing/language.md
@@ -1,8 +1,9 @@
 # Language
 
 * [Writing style](#writing-style)
-    * [Tone of Voice](#tone-of-voice)
+    * [Tone of voice](#tone-of-voice)
     * [Plain English](#plain-english)
+    * [Technical writing](#technical-writing)
 * [Non-discriminatory language](#non-discriminatory-language)
     * [Unacceptable language](#unacceptable-language)
     * [Examples](#examples)
@@ -14,12 +15,12 @@
 
 ## Writing style
 
-We don't enforce strict standards on writing style as we want you to use your own words to express your own personality. That said, we have two general sets of guidelines - Tone of Voice and Plain English.
+We don't enforce strict standards on writing style as we want you to use your own words to express your own personality. That said, we have three general sets of guidelines - tone of voice, plain English, and technical writing.
 
 
-### Tone of Voice
+### Tone of voice
 
-Write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time.
+For a general audience, you should write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time. The exception to this is in writing [technical content](#technical-writing) for a technical audience.
 
 Be thankful to contributors and those who log issues. They're giving up their time to make our playbook better. Make sure they know we're grateful to them.
 
@@ -42,6 +43,16 @@ Follow Plain English guidelines to help safeguard the accessibility of your writ
 - Be informative
   - Consider your audience. General information may not look the same as information aimed at a technical audience.
   - Be as precise as you can usefully be - consider linking to high quality external resources where relevant.
+
+
+### Technical writing
+
+When expressing technical concepts, you'll need to use technical language. This may be complex, contain jargon, or seem formal. That's ok! Technical writing isn't for a general audience. Your priorities must be clarity, brevity, and accuracy, not the emotional impact of your words. 
+
+All of the advice in the [plain English](#plain-english) section applies. Additionally:
+
+- Expand acronyms the first time you use them, and limit their use thereafter e.g. "Avoid the use of TLAs (Three Letter Acronyms)".
+- When defining technical requirements, you may use the keywords defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for those requirement levels, e.g. "MUST", "SHOULD", "OPTIONAL".
 
 
 ## Non-discriminatory language


### PR DESCRIPTION
* Contents reordered to put writing style at the top
* New "non-discriminatory language" section that bundles the related sections
* New "technical writing" section
* Misc consistency fixes to capitalisation, we do/don't do, formatting and links 

Technical writing section is short. There's not really much I can say here that's not already covered in the existing plain english section, so i've made it explicit that concision and structure is better than chatty in technical contexts, and added a link to RFC 2119.

Work to be completed in another PR(s):
* Still not happy with the ordering of this file so I need to take another pass at it
* Need to add 2119 references elsewhere too