### PR TITLE
house-stylify writing guide, break inclusive language into own file

### DIFF
--- a/practices/house-style.md
+++ b/practices/house-style.md
@@ -58,7 +58,7 @@ Read the [code review guide](../practices/code-review.md) for details on how we 
 
 ### Written communications
 
-Not all written communications need to follow house style - for e.g. we don't expect you to follow any rules in Slack, beyond what's expected of you as a professional. If you write for any of our open source repositories (including documentation), [Cruft.io](http://cruft.io/), or any of our [social media accounts](../writing/social-media.md), please familiarise yourself with the [Language guide](../writing/language.md).
+Not all written communications need to follow house style - for e.g. we don't expect you to follow any rules in Slack, beyond what's expected of you as a professional. If you write for any of our open source repositories (including documentation), [Cruft.io](http://cruft.io/), or any of our [social media accounts](../writing/social-media.md), please familiarise yourself with the [Language guide](../writing/house-style.md). Always use [inclusive language](../writing/inclusive-language.md).
 
 
 ## Making changes to the house style

--- a/writing/house-style.md
+++ b/writing/house-style.md
@@ -14,7 +14,7 @@ We don't enforce strict standards on writing style as we want you to use your ow
 
 ### Tone of voice
 
-For a general audience, you should write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time. The exception to this is in writing [technical content](#technical-writing) for a technical audience.
+For a general audience, you should write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time.
 
 Be thankful to contributors and those who log issues. They're giving up their time to make our playbook better. Make sure they know we're grateful to them.
 
@@ -32,7 +32,7 @@ Follow Plain English guidelines to help safeguard the accessibility of your writ
   - Use contractions (e.g. "can't", "it's").
   - Go straight to the point.
 - Be specific
-  - Use the active voice instead of the passive voice (e.g. "NPM will install the dependencies" instead of "the dependencies will be installed").
+  - Prefer the active voice to the passive voice<sup>[\[1\]][active-passive]</sup> (e.g. "NPM will install the dependencies" instead of "the dependencies will be installed").
   - Address the user as "you" where possible.
   - Avoid referring to "things" or "stuff".
   - Be direct. Avoid metaphor, simile, and slang.
@@ -48,7 +48,7 @@ When expressing technical concepts, you'll need to use technical language. This 
 All of the advice in the [plain English](#plain-english) section applies. Additionally:
 
 - Expand acronyms the first time you use them, and limit their use thereafter e.g. "Avoid the use of TLAs (Three Letter Acronyms)".
-- When defining technical requirements, you may use the keywords defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for those requirement levels, e.g. "MUST", "SHOULD", "OPTIONAL".
+- When defining technical requirements, you may use the keywords defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for those requirement levels, e.g. "MUST", "SHOULD", "OPTIONAL", etc.
 
 
 ## Frontend or front-end
@@ -58,3 +58,4 @@ All of the advice in the [plain English](#plain-english) section applies. Additi
 
 
 [writing-well]: http://writersdiet.com/?page_id=16
+[active-passive]: https://oxfordediting.com/the-active-verb-form-makes-academic-writing-more-readable/

--- a/writing/house-style.md
+++ b/writing/house-style.md
@@ -1,0 +1,60 @@
+# Language style guide
+
+* [Writing style](#writing-style)
+    * [Tone of voice](#tone-of-voice)
+    * [Plain English](#plain-english)
+    * [Technical writing](#technical-writing)
+* [Frontend or front-end](#frontend-or-front-end)
+
+
+## Writing style
+
+We don't enforce strict standards on writing style as we want you to use your own words to express your own personality. That said, we have three general sets of guidelines - tone of voice, plain English, and technical writing.
+
+
+### Tone of voice
+
+For a general audience, you should write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time. The exception to this is in writing [technical content](#technical-writing) for a technical audience.
+
+Be thankful to contributors and those who log issues. They're giving up their time to make our playbook better. Make sure they know we're grateful to them.
+
+Maintain the same friendly and professional standards across the entire repository - in documentation, issues, pull requests, and comments.
+
+Always use [inclusive language](inclusive-language.md).
+
+
+### Plain English
+
+Follow Plain English guidelines to help safeguard the accessibility of your written content. All relevant guidelines for [writing well][writing-well] apply. You might find tools like [Hemingway App][hemingway] helpful when editing. In particular:
+
+- Be concise  
+  - Check any sentences with more than 25 words to see if you can split them to make them clearer.
+  - Use contractions (e.g. "can't", "it's").
+  - Go straight to the point.
+- Be specific
+  - Use the active voice instead of the passive voice (e.g. "NPM will install the dependencies" instead of "the dependencies will be installed").
+  - Address the user as "you" where possible.
+  - Avoid referring to "things" or "stuff".
+  - Be direct. Avoid metaphor, simile, and slang.
+- Be informative
+  - Consider your audience. General information may not look the same as information aimed at a technical audience.
+  - Be as precise as you can usefully be - consider linking to high quality external resources where relevant.
+
+
+### Technical writing
+
+When expressing technical concepts, you'll need to use technical language. This may be complex, contain jargon, or seem formal. That's ok! Technical writing isn't for a general audience. Your priorities must be clarity, brevity, and accuracy, not the emotional impact of your words. 
+
+All of the advice in the [plain English](#plain-english) section applies. Additionally:
+
+- Expand acronyms the first time you use them, and limit their use thereafter e.g. "Avoid the use of TLAs (Three Letter Acronyms)".
+- When defining technical requirements, you may use the keywords defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for those requirement levels, e.g. "MUST", "SHOULD", "OPTIONAL".
+
+
+## Frontend or front-end
+
+* Use `front-end` when you need an adjective (e.g. "the front-end team", "front-end principles").
+* Use `frontend` when you need a noun (e.g. "the application's frontend"), when you refer to a repository, or in your code.
+
+
+[writing-well]: http://writersdiet.com/?page_id=16

--- a/writing/inclusive-language.md
+++ b/writing/inclusive-language.md
@@ -1,56 +1,9 @@
-# Language
+# Inclusive language
 
-* [Writing style](#writing-style)
-    * [Tone of voice](#tone-of-voice)
-    * [Plain English](#plain-english)
-    * [Technical writing](#technical-writing)
 * [Non-discriminatory language](#non-discriminatory-language)
     * [Unacceptable language](#unacceptable-language)
     * [Gendered language](#gendered-language)
     * [Disability and accessibility](#disability-and-accessibility)
-* [Frontend or front-end](#frontend-or-front-end)
-
-
-## Writing style
-
-We don't enforce strict standards on writing style as we want you to use your own words to express your own personality. That said, we have three general sets of guidelines - tone of voice, plain English, and technical writing.
-
-
-### Tone of voice
-
-For a general audience, you should write like a human. Be professional, but conversational - we want our contributors and readers to feel comfortable joining in at any time. The exception to this is in writing [technical content](#technical-writing) for a technical audience.
-
-Be thankful to contributors and those who log issues. They're giving up their time to make our playbook better. Make sure they know we're grateful to them.
-
-Maintain the same friendly and professional standards across the entire repository - in documentation, issues, pull requests, and comments.
-
-
-### Plain English
-
-Follow Plain English guidelines to help safeguard the accessibility of your written content. All relevant guidelines for [writing well][writing-well] apply. You might find tools like [Hemingway App][hemingway] helpful when editing. In particular:
-
-- Be concise  
-  - Check any sentences with more than 25 words to see if you can split them to make them clearer.
-  - Use contractions (e.g. "can't", "it's").
-  - Go straight to the point.
-- Be specific
-  - Use the active voice instead of the passive voice (e.g. "NPM will install the dependencies" instead of "the dependencies will be installed").
-  - Address the user as "you" where possible.
-  - Avoid referring to "things" or "stuff".
-  - Be direct. Avoid metaphor, simile, and slang.
-- Be informative
-  - Consider your audience. General information may not look the same as information aimed at a technical audience.
-  - Be as precise as you can usefully be - consider linking to high quality external resources where relevant.
-
-
-### Technical writing
-
-When expressing technical concepts, you'll need to use technical language. This may be complex, contain jargon, or seem formal. That's ok! Technical writing isn't for a general audience. Your priorities must be clarity, brevity, and accuracy, not the emotional impact of your words. 
-
-All of the advice in the [plain English](#plain-english) section applies. Additionally:
-
-- Expand acronyms the first time you use them, and limit their use thereafter e.g. "Avoid the use of TLAs (Three Letter Acronyms)".
-- When defining technical requirements, you may use the keywords defined in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for those requirement levels, e.g. "MUST", "SHOULD", "OPTIONAL".
 
 
 ## Non-discriminatory language
@@ -63,13 +16,14 @@ Language influences thinking. For example, Hebrew uses gender markers, whereas F
 
 Inclusive language is language that is free from words, phrases or tones that reflect prejudiced, stereotyped or discriminatory views of particular people or groups. It is also language that doesn't deliberately or inadvertently exclude people from being seen as part of a group<sup>[\[2\]][govau]</sup>.
 
-We are commited to use inclusive, non-discriminatory language in every written or verbal communication.
+We're committed to using inclusive, non-discriminatory language in every written or verbal communication.
+
 
 ### Unacceptable language
 
 Inappropriate or unacceptable language highlights perceived or actual differences between people. The use of insensitive and inappropriate language can create a hostile environment for people who have protected characteristics, as outlined in the [Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents).
 
-Stereotyping means presuming a range of things about people based on one or two of their personal characteristics such as their appearance, apparent intelligence, personality or character, or their gender, sexual orientation, race, ethnicity, age, location, socioeconomic status or disability. We don't use language that reinforces stereotypes.
+Stereotyping means presuming a range of things about people based on their personal characteristics. These may include their appearance, apparent intelligence, personality or character, or their gender, sexual orientation, race, ethnicity, age, location, socioeconomic status or disability. We don't use language that reinforces stereotypes.
 
 
 ### Gendered language
@@ -125,14 +79,6 @@ The Special Interest Group on Accessible Computing (SIGACCESS) has published a [
 You may also find the more general [gov.uk inclusive language guidance](https://www.gov.uk/government/publications/inclusive-communication/inclusive-language-words-to-use-and-avoid-when-writing-about-disability) helpful.
 
 
-## Frontend or front-end
-
-* Use `front-end` when you need an adjective (e.g. "the front-end team", "front-end principles").
-* Use `frontend` when you need a noun (e.g. "the application's frontend"), when you refer to a repository, or in your code.
-
-
 [govau]: https://www.education.tas.gov.au/documentcentre/Documents/Guidelines-for-Inclusive-Language.pdf "Guidelines for Inclusive Language"
 [hemingway]: http://www.hemingwayapp.com/
-[post]: http://www.poynter.org/2015/the-washington-post-will-allow-singular-they/387542/ "The Washington Post will allow singular ‘they’"
 [wiley]: http://onlinelibrary.wiley.com/doi/10.1111/j.1467-1770.1982.tb00973.x/abstract "Language environment and gender identity attainment"
-[writing-well]: http://writersdiet.com/?page_id=16

--- a/writing/social-media.md
+++ b/writing/social-media.md
@@ -17,8 +17,9 @@ Cruft has also a [@cruftio Twitter account](https://twitter.com/cruftio) that is
 
 Before publishing anything ensure that:
 
-* All the public communications follow our [language standards](language.md).
+* All the public communications follow our [language standards](house-style.md).
 * When reporting bugs or security issues, remember to use positive language instead of blaming.
+* Always use [inclusive language](inclusive-language.md).
 
 We do:
 > Released Shunter 1.2.3. Security upgrade of `nac` to 3.2.1 which addresses several vulns. https://github.com/springernature/shunter/blob/master/HISTORY.md#123-2017-03-08


### PR DESCRIPTION
Our head of Diversity and Inclusion has got me VERY excited.  This PR:

* breaks out section on writing inclusively into its own file (inclusive-language.md)
* changes "language.md" to "house-style.md" to bring it into line with the rest of the Playbook 
* couple of small text changes 
* updates references to the touched files