### PR TITLE
Update the code review AND git docs in one

### DIFF
--- a/git/git.md
+++ b/git/git.md
@@ -23,15 +23,35 @@ We do this:
 frontend-project-name
 ```
 
-## Commit Messages
 
-Your commit messages are your personal legacy.
+## Working with branches
 
-They are the record of what you've done to a codebase and more importantly, *why*.
+Create a local branch based off master.
+
+Follow [Continous Delivery](https://martinfowler.com/bliki/ContinuousDelivery.html) & [Continuous Integration](https://martinfowler.com/articles/continuousIntegration.html) principles as much as is reasonable (given the constraints of your team). Branches should be:
+
+* As short lived as possible.
+* _Atomic_, i.e. one unit of work that can't be sensibly subdivided.
+	* They should contain their own tests.
+	* They should be releasable independently.
+* As limited in scope as possible. Large pull requests are hard to review and can be painful to merge. Also, once merged & a bug is traced back to that commit, they are much harder to debug.
+
+When your work is almost complete, `git rebase master` or merge -- especially if other people are working on the same code. Avoid merge pain by;
+
+* _talking to your team_ to divide work across files sensibly & co-ordinate merges if required.
+* pull origin master & rebase or merge often.
+* make sure branches are short-lived! (Did we mention that branches should be short-lived?)
+
+When the unit of work is complete and tests pass, stage your changes and commit them.
+
+
+## Commit messages
+
+Your commit messages are your personal legacy. They are the record of what you've done to a codebase and more importantly, *why*.
 
 * Make the first line [50 characters or less](http://stopwritingramblingcommitmessages.com/), followed by a blank line.
 * Add more explanatory text if necessary, as detailed as you need. But please make lines wrap at 72 characters.
-* If the work was done in relation to a ticket, include the ticket number in the commit message. **DON'T** only use the ticket number — this just makes life hard for your colleagues to understand what the change was for. The git log should be all they need to read.
+* If your work is part of a ticket, include the ticket number in the commit message. **DON'T** only use the ticket number — this just makes life hard for your colleagues to understand what the change was for. The git log should be all they need to read.
 * Unhelpful messages like "Update" or "Bugfix" are... _unhelpful_. Please explain a little more.
 
 One useful tip for writing great commit messages: imagine your commit message has to make sense prefaced with _"If applied, this commit will..."_.
@@ -43,6 +63,22 @@ A few blog posts on writing better commit messages:
 * [Git Commit](http://chris.beams.io/posts/git-commit/)
 * [Writing Good Commit Messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
 * [Better Commit Messages with a `.gitmessage` Template](https://robots.thoughtbot.com/better-commit-messages-with-a-gitmessage-template)
+
+Once your work is committed, submit a [pull request](https://help.github.com/articles/using-pull-requests/).
+
+
+## Pull requests
+
+We use pull requests to review code. [GitHub's pull request reviews feature](https://help.github.com/articles/about-pull-request-reviews/)  blocks merging of code until it's been reviewed. It may or may not be enabled on a repository, at the discretion of the individual team. You should submit your pull requests for review regardless of whether or not this feature is enabled.
+
+1. Ask for a code review in Slack.
+1. A colleague (or multiple colleagues) other than the author will review the pull request. They will make comments and ask questions directly in the GitHub web interface. See the [Code review guide](../practices/code-review.md) to see what reviewers are looking for. 
+1. When satisfied, the reviewer(s) will approve the pull request, so that your code can be merged.
+1. Give your code one last visual check in github.
+1. Double-check the commit message -- and any commit message detail -- then **"Squash & Merge" commits via github**. We do not want lots of "work in progress" commits cluttering the commit history on master. _One unit of work, one commit._
+
+Your work is now merged, good job! Delete your remote branch, and delete your local branch too, if you want. 
+
 
 ## Versioning
 

--- a/git/git.md
+++ b/git/git.md
@@ -1,7 +1,9 @@
 # Git
 
 * [Repositories](#repositories)
-* [Commit Messages](#commit-messages)
+* [Working with branches](#working-with-branches)
+* [Commit messages](#commit-messages)
+* [Pull requests](#pull-requests)
 * [Versioning](#versioning)
 
 ## Repositories

--- a/practices/code-review.md
+++ b/practices/code-review.md
@@ -1,14 +1,13 @@
 # Code reviews
 
 * [Why](#why)
-* [How](#how)
 * [What to look out for](#what-to-look-out-for)
 
 Code Review, or Peer Code Review, is the act of having your code checked by others for mistakes, errors, and omissions (e.g. missing tests). Like pair-programming (which we also support), it accelerates and streamlines software development.
 
 While we can support "traditional" Code Reviews, we routinely review via **pull requests**. These are communicated in the `#frontend-pr` Slack channel, and managed via GitHub. Discussion should happen in the GitHub comments, not Slack.
 
-We leave it to the requester to merge their own changes when they are ready, because sometimes the requester might not want their work merged immediately.
+Requesters merge their own changes when they're ready. Keep your fingers off that tempting green merge button. 
 
 
 ## Why do them?
@@ -29,36 +28,6 @@ We leave it to the requester to merge their own changes when they are ready, bec
 1. Prepares people for work on [open source software projects](https://github.com/springernature/open-source-directory).
 1. Generally aids onboarding and training.
 
-
-## How
-
-Here's the general process that we use:
-
-1. Create a local branch based off master.
-1. Branches should adhere to the following best practices to ensure they align with [Continous Delivery](https://martinfowler.com/bliki/ContinuousDelivery.html) & [Continuous Integration](https://martinfowler.com/articles/continuousIntegration.html) as much as is reasonable (given the constraints of team structure and the discipline);
-	* Branches should be as short lived as possible.
-	* Branches should be _atomic_ i.e. one unit of work that cannot be sensibly subdivided.
-		* Therefore they should contain their own tests.
-		* Therefore they should be releasable independently.
-	* Branches should be as limited in scope as possible. Large PR's are hard to review and can be painful to merge. Also, once merged & a bug is traced back to that commit, they are much harder to debug.
-1. When you are getting close to being ready for PR, `git rebase master` or merge -- especially if other devs are working on the same code. Avoid merge pain by;
-	* _talking to your team_ to divide work across files sensibly & co-ordinate merges if required.
-	* pull origin master & rebase or merge often.
-	* make sure branches are short-lived! (Did we mention that branches should be short-lived?)
-1. When the unit of work is complete and tests pass, stage the changes and commit them.
-1. Write a [good commit message](../git/git.md#commit-messages).
-1. Submit a [pull request](https://help.github.com/articles/using-pull-requests/).
-1. Ask for a code review in Slack.
-1. A colleague (or multiple colleagues) other than the author reviews the pull request, and they make comments and ask questions directly on lines of code in the GitHub web interface.
-1. When satisfied, the reviewer(s) will approve the pull request indicating that the code is ready to merge.
-1. Give your code one last visual check in github.
-1. Double-check the commit message -- and any commit message detail -- then **"Squash & Merge" commits via github**. We do not want lots of "work in progress" commits cluttering the commit history on master. _One unit of work, one commit._
-1. Delete your remote branch.
-1. (Optional) Delete your local branch.
-
-### What about GitHub's pull request reviews?
-
-[GitHub's pull request reviews feature](https://help.github.com/articles/about-pull-request-reviews/) programatically blocks merging of the code until it has been reviewed, thereby preventing the developer who opened the PR from merging themselves. This feature may or may not be enabled on a repository, at the discretion of the individual team.
 
 ## What to look out for
 

--- a/practices/code-review.md
+++ b/practices/code-review.md
@@ -5,7 +5,7 @@
 
 Code Review, or Peer Code Review, is the act of having your code checked by others for mistakes, errors, and omissions (e.g. missing tests). Like pair-programming (which we also support), it accelerates and streamlines software development.
 
-While we can support "traditional" Code Reviews, we routinely review via **pull requests**. These are communicated in the `#frontend-pr` Slack channel, and managed via GitHub. Discussion should happen in the GitHub comments, not Slack.
+While we can support "traditional" Code Reviews, [we routinely review via **pull requests**](../git/git.md#pull-requests). These are communicated in the `#frontend-pr` Slack channel, and managed via GitHub. Discussion should happen in the GitHub comments, not Slack.
 
 Requesters merge their own changes when they're ready. Keep your fingers off that tempting green merge button. 
 


### PR DESCRIPTION
* Shifts all the stuff that's about git out of code-review.md and into git.md where it belongs.
* Makes the whole thing a bit less list-heavy.
* Lightly edits _some_ of the actual words for brevity.