### PR TITLE
Remove redundant line about linking to element

### DIFF
--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -72,8 +72,6 @@ We couple the loading of JavaScript to the loading of the enhanced CSS. We use t
 })();
 ```
 
-Please note that this JavaScript code will fail in Internet Explorer if there is more than one link element. You can get around this by targeting the specific link element using a class or ID.
-
 ### Caveats
 
 #### Internet Explorer 10 support


### PR DESCRIPTION
This PR will:

- Remove the line describing the need to use an ID, as the example uses the ID.