### PR TITLE
Be more welcoming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Springer Nature front-end playbook
+# The Front-End Playbook
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this playbook are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 ## What's this?
 
-This repo contains the Springer Nature front-end playbook. It details how we run software development and how we make web and mobile products together. It's filled with things we've learned based on our own experience and study of others' experiences.
+This repo contains The Front-End Playbook. It details how we run software development and how we make web and mobile products together. It's filled with things we've learned based on our own experience and study of others' experiences.
 
 See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
 


### PR DESCRIPTION
Given this is now the top Google result for "frontend playbook", I think less prominent mention of ownership is appropriate. It now could be seen as the discipline's de-facto standard frontend playbook.

Advertising/treating it as such, may be beneficial to us (as it will present a more welcoming face), and to others (as they may feel more comfortable utilising it if they can refer to it as a standard, rather than simply a company's preferred way of doing things - which it is as well, but … you know, it's also utilised by many others).

Lots of justification for deleting two words, but that's how I work innit.