### PR TITLE
Add readme files and table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 This repo contains The Front-End Playbook. It details how we run software development and how we make web and mobile products together. It's filled with things we've learned based on our own experience and study of others' experiences.
 
-## Table of contents
+This is a living document that we contribute to in a _public_ GitHub repo. Reasons for doing this in the open include (but are not limited to):
 
-* [Introduction](#whats-this)
+1. Interacting with and learning from others. Receiving contributions from people who don't work here can help us, providing learning opportunities that we would not receive otherwise - for example, see [this contribution](https://github.com/springernature/frontend-playbook/pull/48#issuecomment-236139605) from @rowanmanning.
+
+1. Providing a showcase for our work/ethics. This is _really_ useful when hiring people (for both parties). We've had very positive feedback from interviewees - it's a great recruiting tool. It also means that people are quickly up and running when they join.
+
+See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
+
+## Sections
+
+There's no particular order to which you should read the playbook, but the [Practices section](practices/README.md) is probably a good starting point.
+
 * [Accessibility](accessibility/README.md)
 * [CSS](css/README.md)
 * [Git](git/README.md)
@@ -14,16 +23,6 @@ This repo contains The Front-End Playbook. It details how we run software develo
 * [Practices](practices/README.md)
 * [Security](security/README.md)
 * [Writing](writing/README.md)
-
-## What's this?
-
-This is a living document that we contribute to in a _public_ GitHub repo. Reasons for doing this in the open include (but are not limited to):
-
-1. Interacting with and learning from others. Receiving contributions from people who don't work here can help us, providing learning opportunities that we would not receive otherwise - for example, see [this contribution](https://github.com/springernature/frontend-playbook/pull/48#issuecomment-236139605) from @rowanmanning.
-
-1. Providing a showcase for our work/ethics. This is _really_ useful when hiring people (for both parties). We've had very positive feedback from interviewees - it's a great recruiting tool. It also means that people are quickly up and running when they join.
-
-See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
 # The Front-End Playbook
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this playbook are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-
-## What's this?
-
 This repo contains The Front-End Playbook. It details how we run software development and how we make web and mobile products together. It's filled with things we've learned based on our own experience and study of others' experiences.
 
-See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
+## Table of contents
+
+* [Introduction](#whats-this)
+* [Accessibility](accessibility/README.md)
+* [CSS](css/README.md)
+* [Git](git/README.md)
+* [JavaScript](javascript/README.md)
+* [Markup](markup/README.md)
+* [Performance](performance/README.md)
+* [Practices](practices/README.md)
+* [Security](security/README.md)
+* [Writing](writing/README.md)
+
+## What's this?
 
 This is a living document that we contribute to in a _public_ GitHub repo. Reasons for doing this in the open include (but are not limited to):
 
 1. Interacting with and learning from others. Receiving contributions from people who don't work here can help us, providing learning opportunities that we would not receive otherwise - for example, see [this contribution](https://github.com/springernature/frontend-playbook/pull/48#issuecomment-236139605) from @rowanmanning.
 
 1. Providing a showcase for our work/ethics. This is _really_ useful when hiring people (for both parties). We've had very positive feedback from interviewees - it's a great recruiting tool. It also means that people are quickly up and running when they join.
+
+See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
 
 ### Where do I start?
 
@@ -25,6 +36,10 @@ To contribute please clone the repo (or fork it if you're an external contributo
 Please keep discussion inside the issues and pull requests, avoiding Slack, hallway conversations etc. Remember that this repo is public, and the discussions we have can be of benefit to people apart from us.
 
 [Read the full contributor guide](CONTRIBUTING.md).
+
+## Key words
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this playbook are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ This is a living document that we contribute to in a _public_ GitHub repo. Reaso
 
 See "[Changing the laws of engineering with pull requests](https://www.youtube.com/watch?v=YIpNpptGX6Q)" for an in depth explanation of how developing a playbook like this is of benefit.
 
-### Where do I start?
-
-Begin with the [house style guide](practices/house-style.md).
-
 ## Contributing
 
 To contribute please clone the repo (or fork it if you're an external contributor), create a new branch for your changes, then create a pull request to merge your changes in.

--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -1,0 +1,9 @@
+# Accessibility
+
+Accessibility **must** be a core consideration in all products that we build.
+
+* [House style](house-style.md)
+* [Accessibility checklist](accessibility-checklist.md)
+* [Effective colour contrast](effective-colour-contrast.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/css/README.md
+++ b/css/README.md
@@ -1,0 +1,9 @@
+# CSS
+
+We use Sass to generate CSS, and we organise it using a visual component-led approach.
+
+* [House style](house-style.md)
+* [BEM CSS](bem-css.md)
+* [How we write CSS](how-we-write-css.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/git/README.md
+++ b/git/README.md
@@ -1,0 +1,8 @@
+# git
+
+We use git as a our version control system.
+
+* [git](git.md)
+* [Semver](semver.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,8 @@
+# JavaScript
+
+We use JavaScript both in the client and on the server.
+
+* [House style](house-style.md)
+* [Third-party scripts](third-party-scripts.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/markup/README.md
+++ b/markup/README.md
@@ -1,0 +1,7 @@
+# Markup
+
+We utilise HTML5 for compiled markup.
+
+* [House style](house-style.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,11 @@
+# Performance
+
+Performance refers to the speed in which web pages are downloaded and displayed on the user's browser.
+
+Faster website download speeds have been shown to increase visitor retention and user satisfaction, especially for users with slow internet connections and those on mobile devices. Web performance also leads to less data travelling across the web, which in turn lowers a website's power consumption and environmental impact.
+
+* [Advertising](advertising.md)
+* [Fonts](fonts.md)
+* [Images](images.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/practices/README.md
+++ b/practices/README.md
@@ -1,0 +1,18 @@
+# Practices
+
+Development of products at Springer Nature is informed by two primary constraints:
+
+* The products that Springer Nature produce are used in an enormous variety of contexts, by an enormous variety of users, all of them spread across the planet. We have no way of knowing the situation that any given user could be in. We must deal with:
+  * The variety of technical conditions: Device; operating system; network connection; CPU; browser; screen size; interface; institutional network policies; browser extensions; ISP-injected scripts.
+  * The infinite variety of the human experience: User context; user disabilities; user time limits; user financial status.
+* In order to meet the legal and contractual accessibility obligations of a variety of nation states and large institutional customers we must ensure all of our products adhere to the WCAG 2.1 guidelines, conforming to the “AA” level of Success Criteria .
+
+* [House style](house-style.md)
+* [Code reviews](code-review.md)
+* [Graded browser support](graded-browser-support.md)
+* [Managing node projects](managing-node-projects.md)
+* [Open source support](open-source-support.md)
+* [Progressive enhancement](progressive-enhancement.md)
+* [Structured data](structured-data.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,7 @@
+# Security
+
+Security issues can easily arise through incorrectly built front end code.
+
+* [Secure markup](secure-markup.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/writing/README.md
+++ b/writing/README.md
@@ -1,0 +1,9 @@
+# Writing
+
+We write for a variety of audiences, and we must therefore take that into account whenever we write.
+
+* [House style](house-style.md)
+* [Inclusive language](inclusive-language.md)
+* [Social media](social-media.md)
+
+[Main table of contents](../README.md#table-of-contents)


### PR DESCRIPTION
CHARLIE DID A PR!

It:
* Adds a table of contents to the main `readme.md` file. 
* Slightly reorganizes the main `readme.md` so that it's not immediately shouting at the visitor when they view it. 
* Adds `readme.md` files to each directory, with a mini table of contents.

This is meant as the first step to reorganizing the Playbook and making it easy to use via a published site. 

I've deliberately not attempted to rename the `house-style.md` files to `readme.md` (despite them being obvious candidates) as that could hurt direct external links. I think it would be a lot easier to slowly move content around as appropriate. 