### PR TITLE
Updates section on css grids support with IE10 and IE11

### DIFF
--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -98,13 +98,9 @@ This means that even if we consider IE10 a Core browser, we currently have to se
 
 #### Internet Explorer and CSS Grid
 
-[CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) has been available in all evergreen browsers [for the last year](https://caniuse.com/#feat=css-grid). It offers a much-simplified way of working with layout and offers new design opportunities.
+[CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) has been available in all evergreen browsers [for some time now](https://caniuse.com/#feat=css-grid). It offers a much-simplified way of working with layout and offers new design opportunities.
 
-However, CSS Grid is not available in the full standardised form in Internet Explorer 10 or 11, both of which are currently supported *de facto* as Advanced browsers (see above).
-
-The syntax and capabilities for CSS Grid are radically different in IE than in any other browser. As a result the development costs to match the visual experience in IE with other browsers can range from trivial, for simple component-level layouts, to major for page-level layouts.
-
-We therefore accept that some teams will wish to develop their layouts using CSS Grid, but will not be able to justify devoting time to supporting IE. For those teams we suggest a highly-styled linear layout, which has all the features of an Advanced browser experience, except for the page layout. It is up to any teams making this decision to ensure the IE10/11 Advanced experience is acceptable to their users and business owners.
+However, CSS Grid is not available in the full standardised form in Internet Explorer 10 or 11, both of which are currently supported *de facto* as Advanced browsers (see above). There is an easy to use solution: Autoprefixer. As of version is 9.3.1, by enabling Autoprefixer's grid option, we are now able to reliably generate vendor prefixes for IE10 and IE11. There are a few minor caveats such as ensuring you always define `grid-template-columns` with `grid-template-areas` together if you want `grid-column-gap` to be prefixed correctly. These are well documented in this excellent [article by CSS Tricks](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer).
 
 #### Browsers without TLS 1.2 support
 

--- a/practices/graded-browser-support.md
+++ b/practices/graded-browser-support.md
@@ -100,7 +100,7 @@ This means that even if we consider IE10 a Core browser, we currently have to se
 
 [CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) has been available in all evergreen browsers [for some time now](https://caniuse.com/#feat=css-grid). It offers a much-simplified way of working with layout and offers new design opportunities.
 
-However, CSS Grid is not available in the full standardised form in Internet Explorer 10 or 11, both of which are currently supported *de facto* as Advanced browsers (see above). There is an easy to use solution: Autoprefixer. As of version is 9.3.1, by enabling Autoprefixer's grid option, we are now able to reliably generate vendor prefixes for IE10 and IE11. There are a few minor caveats such as ensuring you always define `grid-template-columns` with `grid-template-areas` together if you want `grid-column-gap` to be prefixed correctly. These are well documented in this excellent [article by CSS Tricks](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer).
+However, CSS Grid is not available in the full standardised form in Internet Explorer 10 or 11, both of which are currently supported *de facto* as Advanced browsers (see above). There is an easy to use solution: Autoprefixer. As of version 9.3.1 we are now able to reliably generate vendor prefixes for IE10 and IE11 by enabling Autoprefixer's grid option. There are a few minor caveats such as ensuring you always define `grid-template-columns` with `grid-template-areas` together if you want `grid-column-gap` to be prefixed correctly. These are well documented [on CSS Tricks](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer).
 
 #### Browsers without TLS 1.2 support
 


### PR DESCRIPTION
Autoprefixer has now got to a point where it's possible to prefix for IE10 and IE11 with little pain or complexity. This means we no longer need to maintain a fallback set of styles when using CSS Grids based on our graded browser support.