### PR TITLE
add developing accessible products page

### DIFF
--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -3,6 +3,7 @@
 Accessibility **must** be a core consideration in all products that we build.
 
 * [House style](house-style.md)
+* [Developing accessible products](developing-accessible-products.md)
 * [Accessibility checklist](accessibility-checklist.md)
 * [Effective colour contrast](effective-colour-contrast.md)
 

--- a/accessibility/developing-accessible-products.md
+++ b/accessibility/developing-accessible-products.md
@@ -1,0 +1,73 @@
+# Developing accessible products
+
+Businesses with an online presence must ensure they make their offering accessible to disabled users. This is a legal obligation that we are required to meet in multiple countries and jurisdictions. 
+
+Certain organisations such as scientific or educational institutions may be prevented by federal regulations from procuring products and services that do not meet accessibility requirements. 
+
+Commercial products are generally covered under civil rights legislation such as the Americans with Disabilities Act in the US or the Equality Act in the UK. If a commercial website is found to be accessible, the website owner can be sued for discrimination under various civil rights legislatory mechanisms.
+
+
+## What is WCAG?
+
+[The Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/TR/WCAG21/) are a set of recommendations for making Web content more accessible to a wider range of people with disabilities. The guidelines address accessibility of web content on desktops, laptops, tablets, and mobile devices. Following these guidelines will also often make Web content more usable to users in general.
+
+Several legal jurisdictions, including those in the US and the EU, explicitly refer to WCAG as the standard to which website operators are expected to adhere. 
+
+Our target standard is WCAG 2.1 AA, in line with the current EU legislation, EN 301 549. All first and third party web products and components published by Springer Nature must conform to WCAG 2.1 AA. 
+
+
+## How do I make sure my product complies?
+
+Accessibility should be considered at every stage of your design and build process, not scheduled as a single clean-up task at the end of the project. Retrofitting accessibility into an inaccessible product is difficult, expensive, and time-consuming. 
+
+
+### Accessible design patterns
+
+When creating interactive components, look for an accessible design pattern before trying to roll your own. There are many resources where you can get ideas: 
+
+* [https://a11yproject.com/patterns](https://a11yproject.com/patterns) 
+* [https://www.w3.org/WAI/tutorials/](https://www.w3.org/WAI/tutorials/) 
+* [https://design-patterns.tink.uk/](https://design-patterns.tink.uk/) 
+* [https://inclusive-components.design/](https://inclusive-components.design/) 
+* [https://design-system.service.gov.uk/components/](https://design-system.service.gov.uk/components/) 
+* [https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex) 
+
+You should still be cautious when using these design patterns. A particular design pattern may be aspirational, and untested with a wide range of Assistive Technology. You must test any “accessible” component that you incorporate to make sure it lives up to its claims. 
+
+Before handing off your product for review, you should do the following:
+
+
+### Automated testing
+
+Automated accessibility testing can be used to detect the most common accessibility problems. This is only the first step in the process; you must not rely on automated testing as your sole method of verification. The GDS Accessibility team ran an experiment in 2017 to [audit the performance of a large number of available automated accessibility testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). They found that the highest number of errors that one tool was able to detect was 40%. The majority of the tools fell into the 20%-30% range. 
+
+At Springer Nature, we use [Pa11y](http://pa11y.org/) and [Axe](https://www.deque.com/axe/). Both of these tools can be installed as part of your Continuous Integration setup if you’re using one, or can otherwise be used on the command line. Axe can also be used in the browser. 
+
+We expect your product to be free of errors when these two tools are passed over it. You’re welcome to use other automated accessibility testing tools in addition to these. 
+
+
+### Manual testing
+
+Manual accessibility testing fills in the gaps that automated tools miss. 
+
+
+#### Guided tests
+
+As a first step for manual testing, we recommend using Microsoft’s [free Accessibility Insights tool](https://accessibilityinsights.io/), a browser extension for Chrome. Use the “Assessment” functionality provided to be guided through the process of assessing a webpage yourself. The “Fast Pass” function is included as part of the “Assessment” process. 
+
+The Fast Pass functionality is based on Axe, but bear in mind that the bundled Axe version may not be in sync with the official package, and you may get inconsistent results if you rely on the version bundled by Microsoft. 
+
+We expect your product to be free of errors that can be identified using this tool. 
+
+
+#### Testing with a screen reader
+
+The Accessibility Insights tool doesn’t cover screen reader testing. We do expect products to be usable in screen readers, so you should conduct your own testing with at least one of these. 
+
+You will need to learn how to use a screen reader, but they are not complicated tools. They are consumer software products, designed to allow ordinary users to interact with websites without a visual display. 
+
+If you don’t use a screen reader regularly, the way that you use it will be different to that of a habitual screen reader user, so be cautious in extrapolating your own experiences to those other users. But also bear in mind that not all regular screen reader users are experts or power users, just like not all users of web browsers are experts. 
+
+If you’re a Mac user, VoiceOver is built-in to OSX and is a decent, basic screen reader. This guide from WebAIM [explains the basics of using VoiceOver to test pages](https://webaim.org/articles/voiceover/). 
+
+If you’re a Windows user, NVDA is one of the more popular screen readers amongst blind users. This guide from WebAIM [explains the basics of using NVDA to test pages](https://webaim.org/articles/nvda/).

--- a/accessibility/developing-accessible-products.md
+++ b/accessibility/developing-accessible-products.md
@@ -4,7 +4,7 @@ Businesses with an online presence must ensure they make their offering accessib
 
 Certain organisations such as scientific or educational institutions may be prevented by federal regulations from procuring products and services that do not meet accessibility requirements. 
 
-Commercial products are generally covered under civil rights legislation such as the Americans with Disabilities Act in the US or the Equality Act in the UK. If a commercial website is found to be accessible, the website owner can be sued for discrimination under various civil rights legislatory mechanisms.
+Commercial products are generally covered under civil rights legislation such as the Americans with Disabilities Act in the US or the Equality Act in the UK. If a commercial website is found to be inaccessible, the website owner can be sued for discrimination under various civil rights legislatory mechanisms.
 
 
 ## What is WCAG?


### PR DESCRIPTION
# What fresh hell is this?

It's a concise guide to building accessible products! 

## But you've already done this in 3 separate pages in this directory

I know, but this time it's _better_!

## Have you finally lost it or what

Obviously yes, but there is a method to my madness. 

The trigger for building this particular page is that we (or rather other people working for the company) sometimes commission work from 3rd parties, or from departments and groups who may have limited experience in actually building accessible content. 

Because we purposefully hire people who get what accessibility is, why it's important, and how it works, the rest of the Playbook assumes a certain level of knowledge and understanding. But if we're commissioning something from another company or even another part of the business where there are no FEDs, we can't rely on that assumption. 

So this particular page is for:

* 3rd party developers, where it will form part of the specification for their deliverables
* Internal developers who have no FEDs or connections to our department and who might be encountering accessibility for the very first time
* Non-technical people involved in procurement decisions in our company and in those from whom we are purchasing services (so they know what we're going to look for before we approve something)

### Yeah great but you've just repeated a load of stuff that's already in the other pages

This is true, and I (or somebody else, maybe even you, if you're volunteering) will fix that in another PR. We need to rejig these docs anyway as part of the "make the Playbook more of a guided experience" work. 

In the meantime, this page has a very particular use case that will hopefully save a bit of back-and-forth between FED Enablement, various commissioned developers, and assorted commissioning parties. 