### PR TITLE
Add a simple performance checklist

### DIFF
--- a/performance/images.md
+++ b/performance/images.md
@@ -38,13 +38,13 @@ Always use the maximum compression level (9).
 
 * Make sure that you save images using an [sRGB](https://en.wikipedia.org/wiki/SRGB) ICC profile. Although modern browsers support images with ICCv2 profiles like [Adobe RGB](https://en.wikipedia.org/wiki/Adobe_RGB_color_space) and even [ProPhoto RGB](https://en.wikipedia.org/wiki/ProPhoto_RGB_color_space), colour space issues are extremely difficult to debug. Saving the images as sRGB and removing the colour profile is encouraged.
 * Strip the metadata from the image. This includes:
-    * EXIF data
-    * Copyright information (unless required)
-    * GPS data
-    * Colour profiles
-    * Thumbnails in JPEGs
-    * Comments
-    * Etc.
+  * EXIF data
+  * Copyright information (unless required)
+  * GPS data
+  * Colour profiles
+  * Thumbnails in JPEGs
+  * Comments
+  * Etc.
 * Set appropriate cache headers for the images. (See [Serving images](#serving-images), below.)
 
 For images that are going to be included in a repo, you can use tools like [ImageOptim](https://imageoptim.com/mac) to optimise them and strip the metadata before committing them.
@@ -56,7 +56,6 @@ If an image is still too big, you can try several other optimisations that will 
 * Reduce noise and other complexity.
 * Decrease export quality.
 * Blur unimportant areas.
-
 
 ## Serving images
 

--- a/performance/performance-checklist.md
+++ b/performance/performance-checklist.md
@@ -1,0 +1,56 @@
+# A simple performance checklist
+
+Web performance is an important consideration in everything that we build, from the early design stages, until a product has reached end-of-life.
+
+This checklist aims to help you and your team create performant products.
+
+Remember that, for most of these rules, there's always the chance that following them may impact performance in a negative way. Always use [any of the tools below](#tooling) to run before/after comparisons.
+
+## HTTP Requests
+
+A lower number of requests is directly related to better performance and higher user engagement. Make sure that the [number of HTTP requests is as small as possible](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch03.html) by:
+
+* Ensuring that there are [no redirects](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch13.html) on the page itself or in any of the first party resources.
+* Ensuring that first party CSS and JS are concatenated, when suitable. This is true even when using HTTP2.
+* Ensuring that no first party resources are returning HTTP 4xx or 5xx errors.
+* Ensure that first party resources are served from as few different domains as possible in order to [reduce DNS lookups](https://www.oreilly.com/library/view/high-performance-web/9780596529307/ch11.html).
+
+## Page weight
+
+Another important factor that impacts user engagement is [the size of the resources](https://blog.chriszacharias.com/page-weight-matters). On low performing networks or devices, the size of the resources being loaded can delay the loading of the page by several seconds and increase power consumption significantly.
+
+* Ensure that all text resources over 1500 bytes [are minified](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch12.html).
+* Ensure that all text resources over 1500 bytes use Brotli, Zopfli or [GZip compression](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch06.html).
+* [Choose the right format for images, and optimise images and SVGs](images.md).
+* Set an [appropriate expiry date or a maximum age](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch05.html) for all static resources.
+* For resources that change rarely, consider [fingerprinting them](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) and setting a expiry date [far in the future](https://developers.google.com/web/tools/lighthouse/audits/cache-policy).
+
+## Render blocking resources
+
+CSS and JS resources can be [render blocking](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources) as the browser will pause rendering of a page while a CSS file or a synchronous JS file or script are being loaded. On slow connections this can delay the page load by several seconds. Ensure there are as few render blocking resources as possible by:
+
+* Ensure all JavaScript files use [`async` or, when possible, `defer` attributes](https://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html).
+* Ensure that only the smallest amount of CSS needed to render the page is being loaded synchronously. [Load the rest of the CSS asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/).
+
+## The critical rendering path
+
+The [critical rendering path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/analyzing-crp) is made up by the resources that are required in order for the browser to complete rendering the current view. By optimizing the critical rendering path you can improve the time to first render of our pages.
+
+* Study the waterfall and find out which resources are in the critical path. Make them load earlier by using [`rel="dns-prefetch"` and `rel="preconnect"`](https://www.keycdn.com/blog/resource-hints) resource hints as appropriate. Ensure that resources [like CSS](https://web.dev/defer-non-critical-css/)that are _not_ in the critical path are loaded asynchronously or lazy-loaded when possible.
+
+## Post launch
+
+* Add the site to [SpeedCurve](https://speedcurve.com) for continuous performance monitoring and alerting. Contact the Frontend Enablement team if you need access to this tool.
+
+## Tooling
+
+The following tools can be used to run performance tests on one or more pages:
+
+* [Lighthouse](https://developers.google.com/web/tools/lighthouse/): A Google tool that audits pages for performance, accessibility, and others. Available as part of [Chrome's devtools](https://developers.google.com/web/tools/lighthouse/#devtools).
+* [WebPagetest](https://www.webpagetest.org/): The standard tool for synthetic web performance testing.
+* Private WebPage test instance: coming soon.
+* [Speedcurve](https://speedcurve.com/): A tool that automates running tests on WebPagetest and provides graphs, trends, and alerts.
+
+## Further resources
+
+* [MDN web docs: Web performance](https://developer.mozilla.org/en-US/docs/Learn/Performance)

--- a/performance/performance-checklist.md
+++ b/performance/performance-checklist.md
@@ -11,7 +11,7 @@ Remember that, for most of these rules, there's always the chance that following
 A lower number of requests is directly related to better performance and higher user engagement. Make sure that the [number of HTTP requests is as small as possible](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch03.html) by:
 
 * Ensuring that there are [no redirects](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch13.html) on the page itself or in any of the first party resources.
-* Ensuring that first party CSS and JS are concatenated, when suitable. This is true even when using HTTP2.
+* Concatenating first party CSS and JS, when suitable. This is true even when using HTTP2.
 * Ensuring that no first party resources are returning HTTP 4xx or 5xx errors.
 * Ensure that first party resources are served from as few different domains as possible in order to [reduce DNS lookups](https://www.oreilly.com/library/view/high-performance-web/9780596529307/ch11.html).
 

--- a/performance/performance-checklist.md
+++ b/performance/performance-checklist.md
@@ -13,7 +13,7 @@ A lower number of requests is directly related to better performance and higher 
 * Ensuring that there are [no redirects](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch13.html) on the page itself or in any of the first party resources.
 * Concatenating first party CSS and JS, when suitable. This is true even when using HTTP2.
 * Ensuring that no first party resources are returning HTTP 4xx or 5xx errors.
-* Ensure that first party resources are served from as few different domains as possible in order to [reduce DNS lookups](https://www.oreilly.com/library/view/high-performance-web/9780596529307/ch11.html).
+* Serve first party resources from as few different domains as possible in order to [reduce DNS lookups](https://www.oreilly.com/library/view/high-performance-web/9780596529307/ch11.html).
 
 ## Page weight
 

--- a/performance/performance-checklist.md
+++ b/performance/performance-checklist.md
@@ -19,7 +19,7 @@ A lower number of requests is directly related to better performance and higher 
 
 Another important factor that impacts user engagement is [the size of the resources](https://blog.chriszacharias.com/page-weight-matters). On low performing networks or devices, the size of the resources being loaded can delay the loading of the page by several seconds and increase power consumption significantly.
 
-* Ensure that all text resources over 1500 bytes [are minified](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch12.html).
+* [Minify all text resources](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch12.html) over 1500 bytes.
 * Ensure that all text resources over 1500 bytes use Brotli, Zopfli or [GZip compression](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch06.html).
 * [Choose the right format for images, and optimise images and SVGs](images.md).
 * Set an [appropriate expiry date or a maximum age](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch05.html) for all static resources.
@@ -29,14 +29,14 @@ Another important factor that impacts user engagement is [the size of the resour
 
 CSS and JS resources can be [render blocking](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources) as the browser will pause rendering of a page while a CSS file or a synchronous JS file or script are being loaded. On slow connections this can delay the page load by several seconds. Ensure there are as few render blocking resources as possible by:
 
-* Ensure all JavaScript files use [`async` or, when possible, `defer` attributes](https://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html).
-* Ensure that only the smallest amount of CSS needed to render the page is being loaded synchronously. [Load the rest of the CSS asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/).
+* Using [`async` or, when possible, `defer` attributes](https://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html) in all JavaScript files.
+* Only loading synchronously the smallest amount of CSS needed to render the page. [Load the rest of the CSS asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/).
 
 ## The critical rendering path
 
 The [critical rendering path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/analyzing-crp) is made up by the resources that are required in order for the browser to complete rendering the current view. By optimizing the critical rendering path you can improve the time to first render of our pages.
 
-* Study the waterfall and find out which resources are in the critical path. Make them load earlier by using [`rel="dns-prefetch"` and `rel="preconnect"`](https://www.keycdn.com/blog/resource-hints) resource hints as appropriate. Ensure that resources [like CSS](https://web.dev/defer-non-critical-css/)that are _not_ in the critical path are loaded asynchronously or lazy-loaded when possible.
+* Study the waterfall and find out which resources are in the critical path. Make them load earlier by using [`rel="dns-prefetch"` and `rel="preconnect"`](https://www.keycdn.com/blog/resource-hints) resource hints as appropriate. Ensure that resources [like CSS](https://web.dev/defer-non-critical-css/) that are _not_ in the critical path are loaded asynchronously or lazy-loaded when possible.
 
 ## Post launch
 


### PR DESCRIPTION
Mirrors the simple a11y checklist that already exists in the playbook.

Also fixes a few whitespace issues in the existing images document.