### PR TITLE
Only one H1 per page please

### DIFF
--- a/accessibility/accessibility-checklist.md
+++ b/accessibility/accessibility-checklist.md
@@ -102,7 +102,7 @@ Resources:
 
 ### Use headings correctly
 
-The [HTML5 outline algorithm](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines) can't yet be relied on to convey information to users. Freely use HTML5 sectioning elements, but use headings to define the structure of your document. See our [HTML markup house style](https://github.com/springernature/frontend-playbook/blob/master/markup/house-style.md#follow-the-html-4-outline-model-for-heading-levels) for more information.
+The [HTML5 outline algorithm](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines) can't yet be relied on to convey information to users. Freely use HTML5 sectioning elements, but use headings to define the structure of your document. In basic terms this means one H1 per page! See our [HTML markup house style](https://github.com/springernature/frontend-playbook/blob/master/markup/house-style.md#follow-the-html-4-outline-model-for-heading-levels) for more information on the outline algorithm and why we don't use multiple level one headings.
 
 Use an appropriate heading for each section. You can visually hide headings, but make sure they're still accessible to screen reader users.
 


### PR DESCRIPTION
this is already explained in the [Markup guide](https://github.com/springernature/frontend-playbook/blob/master/markup/house-style.md#follow-the-html-4-outline-model-for-heading-levels) but the language is a little dense and it's hard to extract the key point from it (which is not to use multiple H1s) unless you already have the cognitive pathway that translates the words "outline algorithm" to "what the spec says about heading structure". 

The key point (don't use multiple H1s) isn't even directly mentioned in the accessibility checklist! This PR fixes that. 