### PR TITLE
Add a tools page

### DIFF
--- a/accessibility/README.md
+++ b/accessibility/README.md
@@ -4,6 +4,7 @@ Accessibility **must** be a core consideration in all products that we build.
 
 * [Introduction](introduction.md)
 * [Developing accessible products](developing-accessible-products.md)
+* [Tools](tools.md)
 * [Accessibility checklist](accessibility-checklist.md)
 * [Accessibility in emails](accessibility-in-emails.md)
 * [Effective colour contrast](effective-colour-contrast.md)

--- a/accessibility/introduction.md
+++ b/accessibility/introduction.md
@@ -103,3 +103,6 @@ The Government Digital Service frequently publishes excellent resources. Some hi
 * [We're making accessibility clearer and easier](https://gds.blog.gov.uk/2017/10/23/were-making-accessibility-clearer-and-easier/)
 * [Making your service accessible: an introduction](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction)
 
+#### Tools 
+
+A breakdown of the tools we recommend for testing accessibility, including assistive technology, can be found on the Playbook [Accessibility tools](tools.md) page. 

--- a/accessibility/introduction.md
+++ b/accessibility/introduction.md
@@ -10,6 +10,7 @@
     - [Guidelines](#guidelines)
     - [Testing with real users](#testing-with-real-users)
     - [Resources](#resources)
+    - [Tools](#tools)
 
 
 ## General principles

--- a/accessibility/introduction.md
+++ b/accessibility/introduction.md
@@ -6,7 +6,7 @@
 - [VPATs](#vpats)
 - [How we conform](#how-we-conform)
   - [Standards](#standards-we-aim-for)
-  - [Tools and techniques](#techniques)
+  - [Techniques](#techniques)
     - [Guidelines](#guidelines)
     - [Testing with real users](#testing-with-real-users)
     - [Resources](#resources)

--- a/accessibility/introduction.md
+++ b/accessibility/introduction.md
@@ -6,11 +6,8 @@
 - [VPATs](#vpats)
 - [How we conform](#how-we-conform)
   - [Standards](#standards-we-aim-for)
-  - [Tools and techniques](#tools-and-techniques)
+  - [Tools and techniques](#techniques)
     - [Guidelines](#guidelines)
-    - [Pa11y](#pa11y)
-    - [Other accessibility testing tools](#other-accessibility-testing-tools)
-    - [Assistive technology](#assistive-technology)
     - [Testing with real users](#testing-with-real-users)
     - [Resources](#resources)
 
@@ -70,7 +67,7 @@ As of January 18th 2018, WCAG 2.0 AA (the previous candidate recommendation) was
 Our expectation is that Section 508 will be updated to reference WCAG 2.1 in due course. Comply with WCAG 2.1 now to avoid retrofitting repairs later!  
 
 
-### Tools and techniques
+### Techniques
 
 #### Guidelines
 
@@ -86,46 +83,6 @@ Use [WAI-ARIA](https://www.w3.org/TR/wai-aria/) roles and properties in your cod
 * Use ARIA roles, properties, or design patterns without testing them with assistive technologies.
 
 The W3C [Using ARIA](https://www.w3.org/TR/using-aria/#NOTES) working draft explains why you shouldn't do those things. Familiarise yourself in particular with the First and Second Rules of ARIA! 
-
-#### Pa11y
-
-We use [Pa11y](http://pa11y.org/) to perform automated accessibility testing. Pa11y is an automated accessibility testing tool that supports [HTML_Codesniffer](https://squizlabs.github.io/HTML_CodeSniffer/) by Squizlabs, and [axe](https://www.deque.com/axe/) by Deque. 
-
-Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. 
-
-Mature projects using Pa11y for the first time MAY use the `threshold` flag to specify a baseline number of errors to allow through, but MUST aim to reduce that threshold to zero at the earliest opportunity. [Watch this talk by Laura Carvajal of the Financial Times](https://www.youtube.com/watch?v=H4FzW9oFObs) to get a high level overview of the concept. 
-
-Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/automated-accessibility-testing-node-travis-ci-pa11y/) to see how to integrate Pa11y with your build process. If you're not using Travis, adjust the setup for the software that you are using. 
-
-You can use HTML_Codesniffer or axe as your test suite; we recommend using both. Neither engine is "better" than the other, they just use different testing strategies. When you fail builds based on Pa11y results, bear in mind that the two engines return different numbers of results, and that the results are formatted differently. 
-
-When using axe, you may prefer to use the standalone [NPM module](https://github.com/dequelabs/axe-core) directly, instead of wrapping it with Pa11y. 
-
-*Caveat:* it's possible to build a site that passes automated testing with flying colours, but is still completely inaccessible for real users. You MUST NOT rely on Pa11y (or axe) as your sole safeguard for accessibility testing. 
-
-
-#### Other accessibility testing tools
-
-- Squizlabs also have an [HMTML_Codesniffer bookmarklet](https://squizlabs.github.io/HTML_CodeSniffer/) for quick tests. 
-- The Axe engine comes as a [browser extension](https://www.deque.com/axe/) and as an [NPM module](https://github.com/dequelabs/axe-core) that you can integrate with your build, like Pa11y. 
-- Google's [Lighthouse](https://developers.google.com/web/tools/lighthouse/) audits accessibility as well as other metrics (e.g. performance) and is available as an extension, in the Chrome dev console, or as a Node CLI tool. 
-- WebAim's [WAVE extension](https://wave.webaim.org/extension/) for Chrome and Firefox evaluates accessibility in place on the page. 
-- Check colour contrast compliance with WebAim's [Colour Contrast Checker](https://webaim.org/resources/contrastchecker/).
-- The [Landmarks browser extension](http://matatk.agrip.org.uk/landmarks/) (for Firefox, Chrome and Opera) enables navigation of WAI-ARIA landmarks, via the keyboard or a pop-up menu.
-- [Funkify](http://www.funkify.org/) is an extension for Chrome that helps you experience the web and interfaces through the eyes of users with different abilities and disabilities.
-
-*Caveat:* None of these tools on their own will catch every error. Even by combining all of them, it's still possible to produce an inaccessible webpage. Terrill Thompson [compared several of the most popular tools](http://terrillthompson.com/blog/730) which should give you some idea of the scale of the problem. The Government Digital Service also [conducted their own tool audit](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). 
-
-You MUST NOT rely on accessibility tools as your sole safeguard for accessibility testing.
-
-
-#### Assistive technology
-
-You're encouraged to test your pages with assistive technology (AT). Many operating systems include some AT as standard, including screenreaders, magnifiers, or input remapping. 
-
-In OSX you can enable [VoiceOver](https://help.apple.com/voiceover/info/guide/10.12/#/) in System Preferences > Accessibility. You may also find navigating without an input device using [Dictation](https://support.apple.com/en-us/HT202584) instructive. Ensure your interfaces work with keyboard navigation. 
-
-*Caveat:* unless you're familiar with using AT, your experience won't be comparable to that of a habitual AT user. Beware of making inferences about what's "easier" for AT users based on your own preferences. 
 
 
 #### Testing with real users

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -4,7 +4,9 @@
   - [Pa11y and axe](#pa11y-and-axe)
 - [Manual testing](#manual-testing)
 - [Assistive technology](#assistive-technology)
-- [Other accessibility testing tools](#other-accessibility-testing-tools)
+- [Other accessibility tools](#other-accessibility-tools)
+  - [Accessibility testing tools in the browser](accessibility-testing-tools-in-the-browser)
+  - [Tools for manually analysing web pages](tools-for-manually-analysing-web-pages)
 - [Simulators](#simulators)
 
 ## Automated testing
@@ -35,8 +37,22 @@ When using axe, you may prefer to use the standalone [NPM module](https://github
 ## Assistive technology
 
 
-## Other accessibility testing tools
+## Other accessibility tools
+
+### Accessibility testing tools in the browser
+
+- Squizlabs also have an [HMTML_Codesniffer bookmarklet](https://squizlabs.github.io/HTML_CodeSniffer/) for quick tests. 
+- The Axe engine comes as a [browser extension](https://www.deque.com/axe/) and as an [NPM module](https://github.com/dequelabs/axe-core) that you can integrate with your build, like Pa11y. 
+- WebAim's [WAVE extension](https://wave.webaim.org/extension/) for Chrome and Firefox evaluates accessibility in place on the page. 
+- Google's [Lighthouse](https://developers.google.com/web/tools/lighthouse/) audits accessibility as well as other metrics (e.g. performance) and is available as an extension, in the Chrome dev console, or as a Node CLI tool. 
+
+
+### Tools for manually analysing web pages
+
+- Check colour contrast compliance with WebAim's [Colour Contrast Checker](https://webaim.org/resources/contrastchecker/).
+- The [Landmarks browser extension](http://matatk.agrip.org.uk/landmarks/) (for Firefox, Chrome and Opera) enables navigation of WAI-ARIA landmarks, via the keyboard or a pop-up menu.
 
 
 ## Simulators
+
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -4,6 +4,7 @@
   - [Pa11y and axe](#pa11y-and-axe)
 - [Manual testing](#manual-testing)
 - [Assistive technology](#assistive-technology)
+  [Screen readers](#screen-readers)
 - [Other accessibility tools](#other-accessibility-tools)
   - [Accessibility testing tools in the browser](accessibility-testing-tools-in-the-browser)
   - [Tools for manually analysing web pages](tools-for-manually-analysing-web-pages)
@@ -33,8 +34,18 @@ When using axe, you may prefer to use the standalone [NPM module](https://github
 
 ## Manual testing
 
+Manual accessibility testing fills in the gaps that automated tools miss. 
+
+- Microsoft’s [free Accessibility Insights tool](https://accessibilityinsights.io/) is a browser extension for Chrome that will guide you through the process of assessing a webpage for basic accessibility compliance. 
+
 
 ## Assistive technology
+
+You're encouraged to test your pages with assistive technology (AT). Many operating systems include some AT as standard, including screenreaders, magnifiers, or input remapping. 
+
+Make sure you test your work at high magnification. You may also find navigating without an input device using [Voice Control](https://support.apple.com/en-au/HT210539) instructive. Ensure your interfaces work with keyboard navigation. 
+
+Unless you're familiar with using AT, your experience won't be comparable to that of a habitual AT user. Beware of making inferences about what's "easier" for AT users based on your own preferences. 
 
 ### Screen readers
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -21,8 +21,8 @@ The GDS Accessibility team ran an experiment in 2017 to [audit the performance o
 
 We use [Pa11y](http://pa11y.org/) to perform automated accessibility testing. Pa11y is an automated accessibility testing tool that supports [HTML_Codesniffer](https://squizlabs.github.io/HTML_CodeSniffer/) by Squizlabs, and [axe](https://www.deque.com/axe/) by Deque. 
 
-Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. 
 Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. We're aiming to make accessibility better, so our baseline is to not make it worse. 
+
 Mature projects using Pa11y for the first time MAY use the `threshold` flag to specify a baseline number of errors to allow through, but MUST aim to reduce that threshold to zero at the earliest opportunity. [Watch this talk by Laura Carvajal of the Financial Times](https://www.youtube.com/watch?v=H4FzW9oFObs) to get a high level overview of the concept. 
 
 Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/automated-accessibility-testing-node-travis-ci-pa11y/) to see how to integrate Pa11y with your build process. If you're not using Travis, adjust the setup for the software that you are using. 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -27,9 +27,7 @@ Mature projects using Pa11y for the first time MAY use the `threshold` flag to s
 
 Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/automated-accessibility-testing-node-travis-ci-pa11y/) to see how to integrate Pa11y with your build process. If you're not using Travis, adjust the setup for the software that you are using. 
 
-You can use HTML_Codesniffer or axe as your test suite; we recommend using both. Neither engine is "better" than the other, they just use different testing strategies. When you fail builds based on Pa11y results, bear in mind that the two engines return different numbers of results, and that the results are formatted differently. 
-
-When using axe, you may prefer to use the standalone [NPM module](https://github.com/dequelabs/axe-core) directly, instead of wrapping it with Pa11y. 
+You can use HTML_Codesniffer or axe as your test suite; we recommend using both. Neither engine is "better" than the other, they just use different testing strategies. When you fail builds based on Pa11y results, bear in mind that the two testing engines return different numbers of results, and their results are formatted differently. 
 
 
 ## Manual testing

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -4,7 +4,7 @@
   - [Pa11y and axe](#pa11y-and-axe)
 - [Manual testing](#manual-testing)
 - [Assistive technology](#assistive-technology)
-  [Screen readers](#screen-readers)
+  - [Screen readers](#screen-readers)
 - [Other accessibility tools](#other-accessibility-tools)
   - [Accessibility testing tools in the browser](accessibility-testing-tools-in-the-browser)
   - [Tools for manually analysing web pages](tools-for-manually-analysing-web-pages)

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -39,6 +39,11 @@ When using axe, you may prefer to use the standalone [NPM module](https://github
 
 ## Other accessibility tools
 
+None of these tools on their own will catch every error. Even by combining all of them, it's still possible to produce an inaccessible webpage. Terrill Thompson [compared several of the most popular tools](http://terrillthompson.com/blog/730) which should give you some idea of the scale of the problem. The Government Digital Service also [conducted their own tool audit](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). 
+
+You MUST NOT rely on these accessibility tools as your sole safeguard for accessibility testing.
+
+
 ### Accessibility testing tools in the browser
 
 - Squizlabs also have an [HMTML_Codesniffer bookmarklet](https://squizlabs.github.io/HTML_CodeSniffer/) for quick tests. 
@@ -54,5 +59,18 @@ When using axe, you may prefer to use the standalone [NPM module](https://github
 
 
 ## Simulators
+
+- [Funkify](http://www.funkify.org/) is an extension for Chrome that helps you experience the web and interfaces through the eyes of users with different abilities and disabilities.
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -22,7 +22,7 @@ The GDS Accessibility team ran an experiment in 2017 to [audit the performance o
 We use [Pa11y](http://pa11y.org/) to perform automated accessibility testing. Pa11y is an automated accessibility testing tool that supports [HTML_Codesniffer](https://squizlabs.github.io/HTML_CodeSniffer/) by Squizlabs, and [axe](https://www.deque.com/axe/) by Deque. 
 
 Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. 
-
+Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. We're aiming to make accessibility better, so our baseline is to not make it worse. 
 Mature projects using Pa11y for the first time MAY use the `threshold` flag to specify a baseline number of errors to allow through, but MUST aim to reduce that threshold to zero at the earliest opportunity. [Watch this talk by Laura Carvajal of the Financial Times](https://www.youtube.com/watch?v=H4FzW9oFObs) to get a high level overview of the concept. 
 
 Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/automated-accessibility-testing-node-travis-ci-pa11y/) to see how to integrate Pa11y with your build process. If you're not using Travis, adjust the setup for the software that you are using. 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -12,9 +12,11 @@
 
 ## Automated testing
 
-Automated accessibility testing can be used to detect the most common accessibility problems. This is only the first step in the process; you MUST NOT rely on automated testing as your sole method of verification! 
+Automated accessibility testing can be used to detect the most common accessibility problems. This is only the first step in the process; you MUST NOT rely on automated testing as your sole method of verification! None of these tools on their own will catch every error. Even by combining all of them, it's still possible to produce an inaccessible webpage. 
 
-The GDS Accessibility team ran an experiment in 2017 to [audit the performance of a large number of available automated accessibility testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). They found that the highest number of errors that one tool was able to detect was 40%. The majority of the tools fell into the 20%-30% range. 
+Terrill Thompson [compared several of the most popular tools](http://terrillthompson.com/blog/730) which should give you some idea of the scale of the problem. The GDS Accessibility team ran an experiment in 2017 to [audit the performance of a large number of available automated accessibility testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). They found that the highest number of errors that one tool was able to detect was 40%. The majority of the tools fell into the 20%-30% range. 
+
+You MUST NOT rely on these accessibility tools as your sole safeguard for accessibility testing.
 
 
 ### Pa11y and axe
@@ -54,11 +56,6 @@ If you’re a Windows user, NVDA is one of the more popular screen readers among
 On mobile, VoiceOver is built-in on iOS devices, and TalkBack is usually built-in on Android devices. 71% of respondents to the [WebAIM Screen Reader User Survey #8](https://webaim.org/projects/screenreadersurvey8/#mobilescreenreaders) use iOS VoiceOver on mobile. 
 
 ## Other accessibility tools
-
-None of these tools on their own will catch every error. Even by combining all of them, it's still possible to produce an inaccessible webpage. Terrill Thompson [compared several of the most popular tools](http://terrillthompson.com/blog/730) which should give you some idea of the scale of the problem. The Government Digital Service also [conducted their own tool audit](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). 
-
-You MUST NOT rely on these accessibility tools as your sole safeguard for accessibility testing.
-
 
 ### Accessibility testing tools in the browser
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -6,8 +6,8 @@
 - [Assistive technology](#assistive-technology)
   - [Screen readers](#screen-readers)
 - [Other accessibility tools](#other-accessibility-tools)
-  - [Accessibility testing tools in the browser](accessibility-testing-tools-in-the-browser)
-  - [Tools for manually analysing web pages](tools-for-manually-analysing-web-pages)
+  - [Accessibility testing tools in the browser](#accessibility-testing-tools-in-the-browser)
+  - [Tools for manually analysing web pages](#tools-for-manually-analysing-web-pages)
 - [Simulators](#simulators)
 
 ## Automated testing
@@ -49,7 +49,7 @@ Unless you're familiar with using AT, your experience won't be comparable to tha
 
 ### Screen readers
 
-If you don’t use a screen reader regularly, the way that you use it will be different to that of a habitual screen reader user, so be cautious in extrapolating your own experiences to those other users. But also bear in mind that not all regular screen reader users are experts or power users, just like not all users of web browsers are experts. 
+If you don’t use a screen reader regularly, the way that you use it will be different to that of a habitual screen reader user, so be cautious in extrapolating your own experiences to those of other users. But also bear in mind that not all regular screen reader users are experts or power users, just like not all users of web browsers are experts. 
 
 If you’re a Mac user, VoiceOver is built-in to OSX and is a decent, basic screen reader. This guide from WebAIM [explains the basics of using VoiceOver to test pages](https://webaim.org/articles/voiceover/). 
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -45,8 +45,6 @@ You're encouraged to test your pages with assistive technology (AT). Many operat
 
 Make sure you test your work at high magnification. You may also find navigating without an input device using [Voice Control](https://support.apple.com/en-au/HT210539) instructive. Ensure your interfaces work with keyboard navigation. 
 
-Unless you're familiar with using AT, your experience won't be comparable to that of a habitual AT user. Beware of making inferences about what's "easier" for AT users based on your own preferences. 
-
 ### Screen readers
 
 If you don’t use a screen reader regularly, the way that you use it will be different to that of a habitual screen reader user, so be cautious in extrapolating your own experiences to those of other users. But also bear in mind that not all regular screen reader users are experts or power users, just like not all users of web browsers are experts. 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -36,6 +36,15 @@ When using axe, you may prefer to use the standalone [NPM module](https://github
 
 ## Assistive technology
 
+### Screen readers
+
+If you don’t use a screen reader regularly, the way that you use it will be different to that of a habitual screen reader user, so be cautious in extrapolating your own experiences to those other users. But also bear in mind that not all regular screen reader users are experts or power users, just like not all users of web browsers are experts. 
+
+If you’re a Mac user, VoiceOver is built-in to OSX and is a decent, basic screen reader. This guide from WebAIM [explains the basics of using VoiceOver to test pages](https://webaim.org/articles/voiceover/). 
+
+If you’re a Windows user, NVDA is one of the more popular screen readers amongst blind users. This guide from WebAIM [explains the basics of using NVDA to test pages](https://webaim.org/articles/nvda/).
+
+On mobile, VoiceOver is built-in on iOS devices, and TalkBack is usually built-in on Android devices. 71% of respondents to the [WebAIM Screen Reader User Survey #8](https://webaim.org/projects/screenreadersurvey8/#mobilescreenreaders) use iOS VoiceOver on mobile. 
 
 ## Other accessibility tools
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -60,17 +60,14 @@ You MUST NOT rely on these accessibility tools as your sole safeguard for access
 
 ## Simulators
 
+Disability simulators are apps, extensions, or experiments that imitate the experience of being disabled for able-bodied people. They're designed to increase empathy and awareness of the issues facing disabled people. 
+
+It's very important that you understand the limitations of disability simulators. No browser extension could ever give you an appreciation of what it's like to navigate the world as a disabled person. No blindfold game can teach you what it's like to be systematically discriminated against in virtually every aspect of your daily life. You can just switch the simulator off - a 
+disabled person doesn't have that option. 
+
+If used carelessly, disability simulators can also have the opposite effect of what's intended. Instead of giving able-bodied people empathy with those who experience disability in a particular context, they can elicit sympathy or pity reactions. Pity reactions lead to responses like "that's terrible", and not "how can we help?". As web professionals who care about the experiences of all of our users, we need to make sure our response to any disability simulators is "how can we help?". The [June 2017 issue of Braille Monitor](https://www.nfb.org/images/nfb/publications/bm/bm17/bm1706/bm170602.htm) discusses the research on disability simulation, its limitations, and how it can be improved. 
+
+With this caveat in mind, here are some disability simulators that _may_ help you or your team understand _some_ of the ways in which people with some disabilities may perceive your web pages. 
+
 - [Funkify](http://www.funkify.org/) is an extension for Chrome that helps you experience the web and interfaces through the eyes of users with different abilities and disabilities.
-
-
-
-
-
-
-
-
-
-
-
-
-
+- [Empathy prompts](https://empathyprompts.net/) are flashcards with things to consider when making things for others to use.

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -1,0 +1,26 @@
+# Accessibility tools
+
+- [Automated testing](#automated-testing)
+  - [Pa11y and axe](#pa11y-and-axe)
+- [Manual testing](#manual-testing)
+- [Assistive technology](#assistive-technology)
+- [Other accessibility testing tools](#other-accessibility-testing-tools)
+- [Simulators](#simulators)
+
+## Automated testing
+
+
+### Pa11y and axe
+
+
+## Manual testing
+
+
+## Assistive technology
+
+
+## Other accessibility testing tools
+
+
+## Simulators
+

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -9,6 +9,9 @@
 
 ## Automated testing
 
+Automated accessibility testing can be used to detect the most common accessibility problems. This is only the first step in the process; you MUST NOT rely on automated testing as your sole method of verification! 
+
+The GDS Accessibility team ran an experiment in 2017 to [audit the performance of a large number of available automated accessibility testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). They found that the highest number of errors that one tool was able to detect was 40%. The majority of the tools fell into the 20%-30% range. 
 
 ### Pa11y and axe
 

--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -13,7 +13,20 @@ Automated accessibility testing can be used to detect the most common accessibil
 
 The GDS Accessibility team ran an experiment in 2017 to [audit the performance of a large number of available automated accessibility testing tools](https://accessibility.blog.gov.uk/2017/02/24/what-we-found-when-we-tested-tools-on-the-worlds-least-accessible-webpage/). They found that the highest number of errors that one tool was able to detect was 40%. The majority of the tools fell into the 20%-30% range. 
 
+
 ### Pa11y and axe
+
+We use [Pa11y](http://pa11y.org/) to perform automated accessibility testing. Pa11y is an automated accessibility testing tool that supports [HTML_Codesniffer](https://squizlabs.github.io/HTML_CodeSniffer/) by Squizlabs, and [axe](https://www.deque.com/axe/) by Deque. 
+
+Projects MUST have Pa11y integrated at the build stage, and builds MUST fail if errors are introduced. You MUST NOT allow accessibility regressions to enter your project's codebase. 
+
+Mature projects using Pa11y for the first time MAY use the `threshold` flag to specify a baseline number of errors to allow through, but MUST aim to reduce that threshold to zero at the earliest opportunity. [Watch this talk by Laura Carvajal of the Financial Times](https://www.youtube.com/watch?v=H4FzW9oFObs) to get a high level overview of the concept. 
+
+Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/automated-accessibility-testing-node-travis-ci-pa11y/) to see how to integrate Pa11y with your build process. If you're not using Travis, adjust the setup for the software that you are using. 
+
+You can use HTML_Codesniffer or axe as your test suite; we recommend using both. Neither engine is "better" than the other, they just use different testing strategies. When you fail builds based on Pa11y results, bear in mind that the two engines return different numbers of results, and that the results are formatted differently. 
+
+When using axe, you may prefer to use the standalone [NPM module](https://github.com/dequelabs/axe-core) directly, instead of wrapping it with Pa11y. 
 
 
 ## Manual testing


### PR DESCRIPTION
The accessibility introduction is more of an infodump than an introduction. This PR:

* Creates a new tools.md document
* Moves all the stuff about tools out of the introduction and into the tools doc
* Splits the tool types into sections depending on what they're trying to achieve
* Changes the suggestion of using Dictation on Mac to a suggestion of using Voice Control (released in MacOS Catalina)]
* Adds a really gigantic caveat to the disability simulator section 
* Adds an extra link to the disability simulator section

(Some of the additional content is copied from developing-accessible-products.md)