### PR TITLE
Clarify that the text label should be visible

### DIFF
--- a/accessibility/accessibility-checklist.md
+++ b/accessibility/accessibility-checklist.md
@@ -219,7 +219,7 @@ Make sure the currently-focused element has a focus ring, and make sure the focu
 
 This can be disorientating to screen reader users or users with cognitive disabilites.
 
-If you must do it, warn the user _before_ they click on the link that it'll open in a new window. You can use text like "opens in a new window" or a visual icon. If you choose to use an icon, make sure it's accessible to screen reader users.
+If you must do it, warn the user _before_ they click on the link that it'll open in a new window. You can use visible text like "opens in a new window" or a visual icon. If you choose to use an icon, make sure it's accessible to screen reader users.
 
 Resources:
 


### PR DESCRIPTION
* Visually-hidden text label in the control name doesn't help sighted users 
* Violates the principle of parity between the visible UI and the contents of the accessibility tree
* Visually-hidden text in a control could potentially cause problems for speech input users