### PR TITLE
Javascript dependent styling

### DIFF
--- a/css/house-style.md
+++ b/css/house-style.md
@@ -149,13 +149,13 @@ table {
 }
 ```
 
-**Non-js fallbacks/JS only styles**. We do this:
+**Javascript-only style enhancements**. We do this:
 ```scss
 .c-class {
 	display: block;
 
     .js & {
-        display: none;
+        display: flex;
     }
 }
 ```

--- a/css/house-style.md
+++ b/css/house-style.md
@@ -152,14 +152,14 @@ table {
 **Non-js fallbacks/JS only styles**. We do this:
 ```scss
 .c-class {
+	display: block;
+
     .js & {
         display: none;
     }
-    .no-js & {
-        display: block;
-    }
 }
 ```
+> _Read more about [how to add the `.js` class](../practices/javascript-styling.md)_
 
 **Inline html tags within other elements**. We do this:
 ```scss

--- a/javascript/house-style.md
+++ b/javascript/house-style.md
@@ -21,17 +21,11 @@ This document outlines the way we write JavaScript. It's a living style guide â€
     - [Further reading](#further-reading)
   - [Indentation](#indentation)
   - [White space](#white-space)
-  - [Semi-colons](#semi-colons)
   - [Variables](#variables)
   - [Functions](#functions)
     - [Pure functions](#pure-functions)
-    - [Arguments](#arguments)
-  - [Classes](#classes)
   - [Operators](#operators)
-  - [Blocks](#blocks)
-    - [Conditionals](#conditionals)
-    - [Loops](#loops)
-    - [Error handling](#error-handling)
+  - [Loops](#loops)
   - [Strict mode](#strict-mode)
 - [Client-side JavaScript architecture](#client-side-javascript-architecture)
   - [Module architecture](#module-architecture)
@@ -506,7 +500,7 @@ foo == bar;
 foo != bar;
 ```
 
-#### Loops
+### Loops
 
 In `for...in` loops, there must be a check with `hasOwnProperty`.
 

--- a/practices/README.md
+++ b/practices/README.md
@@ -14,5 +14,6 @@ Development of products at Springer Nature is informed by two primary constraint
 * [Open source support](open-source-support.md)
 * [Progressive enhancement](progressive-enhancement.md)
 * [Structured data](structured-data.md)
+* [Javascript dependent styling](javascript-styling.md)
 
 [Main table of contents](../README.md#table-of-contents)

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -19,7 +19,7 @@ The blocking nature of the script prevents any visual flickering or browser refl
 
 All UI elements MUST be usable and visually-acceptable when Javascript is not present. Enhancements can be made when Javascript is present by nesting those styles underneath the `.js` class.
 
-Following the principles of [Progressive Enhancement](./progressive-enhancement.md), consider buiding and releasing your core unenhanced version first. Then build and deliver the javascript enhanced version in a subsequent iteration.
+Following the principles of [Progressive Enhancement](./progressive-enhancement.md), consider building and releasing your core unenhanced version first. Then build and deliver the Javascript enhanced version in a subsequent iteration.
 
 ```scss
 // Define core styles

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -4,7 +4,9 @@ A class name of `.js` on the document root element (normally `html`) is used to 
 
 ## Scripts
 
-The `.js` class must be added via a micro (but blocking) script, placed as far up in the `<head>` of the document as possible.
+The `.js` class must be added via a micro—but blocking—script, placed as far up in the `<head>` of the document as possible.
+
+The blocking nature of the script prevents any visual flickering or browser reflows, unlike other techniques where JavaScript may cause styles to be applied after the page has rendered.
 
 ```html
 <script>

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -1,6 +1,6 @@
 # Javascript dependent styling
 
-A class name of `.js` on the document root element (normally `html`) will be used to bootstrap JS-only visual styles. We do this to prevent the visual flicker and browser reflow that may occur when JavaScript applies CSS styles to a component after the page has loaded.
+A class name of `.js` on the document root element (normally `html`) is used to target JS-dependent visual styles via CSS.
 
 ## Scripts
 

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -1,0 +1,35 @@
+# Javascript dependent styling
+
+A class name of `.js` on the document root element (normally `html`) will be used to bootstrap JS-only visual styles. We do this to prevent the visual flicker and browser reflow that may occur when JavaScript applies CSS styles to a component after the page has loaded.
+
+## Scripts
+
+The `.js` class must be added via a micro (but blocking) script, placed as far up in the `<head>` of the document as possible.
+
+```html
+<script>
+    // JS Detection Script
+    (function(e){var t=e.documentElement,n=e.implementation;t.className='js';})(document)
+</script>
+```
+
+## Styles
+
+All UI elements MUST be usable and visually-acceptable when Javascript is not present. Enhancements can be made when Javascript is present by nesting those styles underneath the `.js` class.
+
+```scss
+// Define a base style
+.c-component {
+	color: black;
+	padding-bottom: 1rem;
+
+}
+
+// Add and override declarations when JS is present
+.js .c-component {
+	height: 200px;
+	padding-bottom: 0; // overridden now that JS is present
+	background-color: #e4e4e4;
+	margin: 10px;
+}
+```

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -24,16 +24,15 @@ Following the principles of [Progressive Enhancement](./progressive-enhancement.
 ```scss
 // Define core styles
 .c-component {
-	color: black;
-	padding-bottom: 1rem;
-
+    color: black;
+    padding-bottom: 1rem;
 }
 
 // Add and override declarations when JS is present
 .js .c-component {
-	height: 200px;
-	padding-bottom: 0; // overridden now that JS is present
-	background-color: #e4e4e4;
-	margin: 10px;
+    height: 200px;
+    padding-bottom: 0; // overridden now that JS is present
+    background-color: #e4e4e4;
+    margin: 10px;
 }
 ```

--- a/practices/javascript-styling.md
+++ b/practices/javascript-styling.md
@@ -19,8 +19,10 @@ The blocking nature of the script prevents any visual flickering or browser refl
 
 All UI elements MUST be usable and visually-acceptable when Javascript is not present. Enhancements can be made when Javascript is present by nesting those styles underneath the `.js` class.
 
+Following the principles of [Progressive Enhancement](./progressive-enhancement.md), consider buiding and releasing your core unenhanced version first. Then build and deliver the javascript enhanced version in a subsequent iteration.
+
 ```scss
-// Define a base style
+// Define core styles
 .c-component {
 	color: black;
 	padding-bottom: 1rem;


### PR DESCRIPTION
Add a section in `practices` about how to bootstrap Javascript dependent styles, then link to the information when we talk about it in CSS house style. Mostly cribbed from something @sonniesedge wrote (🙏 ) but removing specific references to components and the design system.

(Also fixes some dead links from the Javascript house style TOC)