### PR TITLE
recommend axe Accessibility Linter for VS Code

### DIFF
--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -31,6 +31,8 @@ Read [Automated accessibility testing with Travis CI](http://cruft.io/posts/auto
 
 You can use HTML_Codesniffer or axe as your test suite; we recommend using both. Neither engine is "better" than the other, they just use different testing strategies. When you fail builds based on Pa11y results, bear in mind that the two testing engines return different numbers of results, and their results are formatted differently. 
 
+If you're a VS Code user, you can also install Deque's [axe accessibility linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter) from the Visual Studio marketplace and catch some common accessibility errors before they get to the build stage. 
+
 
 ## Manual testing
 


### PR DESCRIPTION
Deque have released a linter for VS Code, so now you can catch problems more earlier in yer dev process. This PR adds a recommendation that you do so.

Here is the announcement: https://www.deque.com/blog/shift-further-left-with-deques-axe-linter-for-vs-code/