### PR TITLE
Remove dead link, add Plain English campaign link

### DIFF
--- a/writing/house-style.md
+++ b/writing/house-style.md
@@ -22,7 +22,7 @@ Always use [inclusive language](inclusive-language.md).
 
 ### Plain English
 
-Follow Plain English guidelines to help safeguard the accessibility of your written content. All relevant guidelines for [writing well][writing-well] apply. You might find tools like [Hemingway App](http://www.hemingwayapp.com/) helpful when editing. In particular:
+Follow [Plain English guidelines](http://www.plainenglish.co.uk/how-to-write-in-plain-english.html) to help safeguard the accessibility of your written content. You might find tools like [Hemingway App](http://www.hemingwayapp.com/) helpful when editing. In particular:
 
 * Be concise
   * Check any sentences with more than 25 words to see if you can split them to make them clearer.
@@ -52,5 +52,4 @@ All of the advice in the [plain English](#plain-english) section applies. Additi
 
 Always use `frontend` regardless of the context. It's less confusing and error prone, and ensures consistency across all our documentation and portfolio of products.
 
-[writing-well]: http://writersdiet.com/?page_id=16
 [active-passive]: https://oxfordediting.com/the-active-verb-form-makes-academic-writing-more-readable/


### PR DESCRIPTION
The Writer's Diet website doesn't provide writing advice anymore, so this link needs to go. 

Instead I've linked to the Plain English Campaign website, which I probably should have done in the first place 🤷‍♀️ 

Resolves #383 