### PR TITLE
Add comment to internal link on code-review.md

### DIFF
--- a/practices/code-review.md
+++ b/practices/code-review.md
@@ -34,7 +34,7 @@ Requesters merge their own changes when they're ready. Keep your fingers off tha
 * **Accessibility**
 
   * [Accessibility](../accessibility/accessibility-checklist.md) problems. Suggest testing with [pa11y](https://github.com/pa11y) and/or other tools.
-    * [internal-only pa11y dashboard](http://pa11y.springernature.com/)
+    * [pa11y dashboard](http://pa11y.springernature.com/) _(link only works if inside the Springer Nature VPN)_
 
 * **Complexity**
 


### PR DESCRIPTION
Adding a more explicit comment about an internal-only pa11y link.
Closes #391.