### PR TITLE
Move ARC toolkit into the right section

### DIFF
--- a/accessibility/tools.md
+++ b/accessibility/tools.md
@@ -64,13 +64,12 @@ On mobile, VoiceOver is built-in on iOS devices, and TalkBack is usually built-i
 - Squizlabs also have an [HMTML_Codesniffer bookmarklet](https://squizlabs.github.io/HTML_CodeSniffer/) for quick tests. 
 - The Axe engine comes as a [browser extension](https://www.deque.com/axe/browser-extensions/) for Chrome, Firefox, and Edge, and as an [NPM module](https://github.com/dequelabs/axe-core) that you can integrate with your build, like Pa11y. 
 - WebAim's [WAVE extension](https://wave.webaim.org/extension/) for Chrome and Firefox evaluates accessibility in place on the page. 
-
+- The [ARC Toolkit](https://www.paciellogroup.com/toolkit/) by the Paciello Group is a useful extension for Chrome that (among other things) can detect semantic/structural issues, and problematic use of ARIA. 
 
 ### Tools for manually analysing web pages
 
 - Check colour contrast compliance with WebAim's [Colour Contrast Checker](https://webaim.org/resources/contrastchecker/).
 - The [Landmarks browser extension](http://matatk.agrip.org.uk/landmarks/) (for Firefox, Chrome and Opera) enables navigation of WAI-ARIA landmarks, via the keyboard or a pop-up menu.
-- The [ARC Toolkit](https://www.paciellogroup.com/toolkit/) by the Paciello Group is a useful extension for Chrome that (among other things) can detect semantic/structural issues, and problematic use of ARIA. 
 
 
 ## Simulators


### PR DESCRIPTION
For some mysterious reason I put the ARC toolkit into the manual testing tools section, instead of in the automated tools section where it belongs 🤷‍♀️ 