### PR TITLE
Add new Learning section

### DIFF
--- a/accessibility/introduction.md
+++ b/accessibility/introduction.md
@@ -1,18 +1,17 @@
 # Accessibility
 
-- [General Principles](#general-principles)
-  - [What is accessibility?](#what-is-accessibility)
-  - [Why do we care about accessibility?](#why-do-we-care-about-accessibility)
-- [VPATs](#vpats)
-- [How we conform](#how-we-conform)
-  - [Standards](#standards-we-aim-for)
-  - [Techniques](#techniques)
-    - [Web Content Accessibility Guidelines](#web-content-accessibility-guidelines)
-    - [WAI-ARIA Authoring Practices](#wai-aria-authoring-practices)    
-    - [Testing with real users](#testing-with-real-users)
-    - [Resources](#resources)
-    - [Tools](#tools)
-
+* [General principles](#general-principles)
+  * [What is accessibility?](#what-is-accessibility)
+  * [Why do we care about accessibility?](#why-do-we-care-about-accessibility)
+* [VPATs](#vpats)
+* [How we conform](#how-we-conform)
+  * [Standards we aim for](#standards-we-aim-for)
+  * [Techniques](#techniques)
+    * [Web Content Accessibility Guidelines](#web-content-accessibility-guidelines)
+    * [WAI-ARIA Authoring Practices](#wai-aria-authoring-practices)
+    * [Testing with real users](#testing-with-real-users)
+    * [Resources](#resources)
+    * [Tools](#tools)
 
 ## General principles
 
@@ -20,7 +19,6 @@
 > Access by everyone regardless of disability is an essential aspect.
 >
 > _Tim Berners-Lee, inventor of the World Wide Web_
-
 
 ### What is accessibility?
 
@@ -32,12 +30,11 @@ It is essential that the Web be accessible in order to provide equal access and 
 
 Accessibility supports social inclusion for people with disabilities as well as others, such as older people, people in rural areas, and people in developing countries.
 
-
 ### Why do we care about accessibility?
-  
-- *It's a legal requirement:* we're legally obliged in almost all jurisdictions worldwide to make our content accessible to users with diverse needs. We SHOULD comply with [US Section 508](https://www.section508.gov/) of the US Rehabilitation Act 1973, the [UK Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents), and [The Americans with Disabilities Act of 1990 and Revised ADA Regulations Implementing Title II and Title III](https://www.ada.gov/2010_regs.htm). 
-- *It makes financial sense:* around 20% of working age adults in the UK are estimated to have some kind of permanent disability (Source: [Scope UK](https://www.scope.org.uk/media/disability-facts-figures)). Forrester Research found that *_57%_* of computer users aged 18 to 64 are "likely or very likely" to benefit from the use of assistive technology (Sources: [Microsoft](https://www.microsoft.com/en-us/download/details.aspx?id=18446), [Pubmed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2788505/)). Also taking into account people who are [temporarily disabled](https://userway.org/blog/how-situational-disabilities-impact-us-all), failing to make our websites accessible can cause a significant reduction in real market share. 
-- *It's a technical requirement:* catering for all users complements our [browser support policy](../practices/graded-browser-support.md) (we aim to support all browsers), and our use of [progressive enhancement](../practices/progressive-enhancement.md). 
+
+- *It's a legal requirement:* we're legally obliged in almost all jurisdictions worldwide to make our content accessible to users with diverse needs. We SHOULD comply with [US Section 508](https://www.section508.gov/) of the US Rehabilitation Act 1973, the [UK Equality Act 2010](http://www.legislation.gov.uk/ukpga/2010/15/contents), and [The Americans with Disabilities Act of 1990 and Revised ADA Regulations Implementing Title II and Title III](https://www.ada.gov/2010_regs.htm).
+- *It makes financial sense:* around 20% of working age adults in the UK are estimated to have some kind of permanent disability (Source: [Scope UK](https://www.scope.org.uk/media/disability-facts-figures)). Forrester Research found that *_57%_* of computer users aged 18 to 64 are "likely or very likely" to benefit from the use of assistive technology (Sources: [Microsoft](https://www.microsoft.com/en-us/download/details.aspx?id=18446), [Pubmed](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2788505/)). Also taking into account people who are [temporarily disabled](https://userway.org/blog/how-situational-disabilities-impact-us-all), failing to make our websites accessible can cause a significant reduction in real market share.
+- *It's a technical requirement:* catering for all users complements our [browser support policy](../practices/graded-browser-support.md) (we aim to support all browsers), and our use of [progressive enhancement](../practices/progressive-enhancement.md).
 - *It's the right thing to do:* we have a duty to cater for all users regardless of ability. If we know that people can encounter difficulties accessing our content (which we do), and we know that we can do things to facilitate that access (which we do), then not making something accessible is knowingly contributing to the oppression of people with disabilities.
 
 Accessible sites can be used by more people - including people with disabilities, people using mobile devices, older people, people with low literacy, people who are not fluent in the language of the site, people with low bandwidth connections to the Internet, people with older technologies, and new and infrequent web users.
@@ -53,8 +50,7 @@ A Voluntary Product Accessibility Template (VPAT) is a reporting format document
 
 A VPAT MUST be produced by you or your team for every product or service that we make commercially available in the United States. If something changes, e.g. accessibility is improved for a particular criteria, you MUST update the VPAT to reflect the change. You MUST NOT regress accessibility to below the level detailed in the VPAT.
 
-You may use [our VPAT template](https://github.com/springernature/vpat) when evaluating your own products. 
-
+You may use [our VPAT template](https://github.com/springernature/vpat) when evaluating your own products.
 
 ## How we conform
 
@@ -64,10 +60,9 @@ Our target standards are [WCAG 2.1](https://www.w3.org/TR/WCAG21/) level AA.
 
 As of mid-September 2018, WCAG 2.1 AA has been adopted in the European [EN 301 549 “Accessibility requirements for ICT products and services”](https://www.w3.org/blog/2018/09/wcag-2-1-adoption-in-europe/). This means that in order to comply with EN 301 549, your products MUST also comply with WCAG 2.1 to level AA.
 
-As of January 18th 2018, WCAG 2.0 AA (the previous candidate recommendation) was incorporated by reference into Section 508 (see [Section 508 Refresh Part 1](https://www.paciellogroup.com/blog/2017/01/section-508-refresh-part-1/) by the Paciello Group). 
+As of January 18th 2018, WCAG 2.0 AA (the previous candidate recommendation) was incorporated by reference into Section 508 (see [Section 508 Refresh Part 1](https://www.paciellogroup.com/blog/2017/01/section-508-refresh-part-1/) by the Paciello Group).
 
-Our expectation is that Section 508 will be updated to reference WCAG 2.1 in due course. Comply with WCAG 2.1 now to avoid retrofitting repairs later!  
-
+Our expectation is that Section 508 will be updated to reference WCAG 2.1 in due course. Comply with WCAG 2.1 now to avoid retrofitting repairs later!
 
 ### Techniques
 
@@ -77,7 +72,7 @@ You're expected to be aware of the [Web Content Accessibility Guidelines](https:
 
 The companion document [Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/) (Editor's Draft) explains what each of the success criterion in WCAG 2.1 actually means. You might also find the [Techniques for WCAG 2.1](https://www.w3.org/WAI/WCAG21/Techniques/) (Editor's Draft) useful when building features. 
 
-W3C WAI have published a [quick reference document for WCAG](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0). It describes the WCAG success criteria and shows techniques and failures for each. We've also created [a simple accessibility checklist](accessibility-checklist.md), to help you become familiar with the guidelines/standards, and to aid you when manually assessing pages. 
+W3C WAI have published a [quick reference document for WCAG](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0). It describes the WCAG success criteria and shows techniques and failures for each. We've also created [a simple accessibility checklist](accessibility-checklist.md), to help you become familiar with the guidelines/standards, and to aid you when manually assessing pages.
 
 #### WAI-ARIA Authoring Practices
 
@@ -86,27 +81,18 @@ Use [WAI-ARIA](https://www.w3.org/TR/wai-aria/) roles and properties and [WAI-AR
 * Use ARIA roles, properties, or design patterns without understanding what they do;
 * Use ARIA roles, properties, or design patterns without testing them with assistive technologies.
 
-The W3C [Using ARIA](https://www.w3.org/TR/using-aria/#NOTES) working draft explains why you shouldn't do those things. Familiarise yourself in particular with the First and Second Rules of ARIA! 
-
+The W3C [Using ARIA](https://www.w3.org/TR/using-aria/#NOTES) working draft explains why you shouldn't do those things. Familiarise yourself in particular with the First and Second Rules of ARIA!
 
 #### Testing with real users
 
-The best way to learn if your website works for people with disabilities is to get people with disabilities to test it for you. 
+The best way to learn if your website works for people with disabilities is to get people with disabilities to test it for you.
 
-You can arrange your own user testing, but it's better to engage a third party like the [Digital Accessibility Centre](http://www.digitalaccessibilitycentre.org/) to do this work for you. As professionals who specialise in accessibility testing and making recommendations, they're better at it than you. 
-
+You can arrange your own user testing, but it's better to engage a third party like the [Digital Accessibility Centre](http://www.digitalaccessibilitycentre.org/) to do this work for you. As professionals who specialise in accessibility testing and making recommendations, they're better at it than you.
 
 #### Resources
 
-Udacity have published an [excellent free course on Web Accessibility](https://www.udacity.com/course/web-accessibility--ud891) with Google engineers Alice Boxhall and Rob Dodson. 
+You can find a [list of accessibility-related resources](../learning/accessibility.md) in the [Learning section of the Playbook](../learning/README.md).
 
-The Financial Times have produced an [accessibility tip sheet](https://ft-interactive.github.io/accessibility/index.html).
+#### Tools
 
-The Government Digital Service frequently publishes excellent resources. Some highlights are:
-
-* [We're making accessibility clearer and easier](https://gds.blog.gov.uk/2017/10/23/were-making-accessibility-clearer-and-easier/)
-* [Making your service accessible: an introduction](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction)
-
-#### Tools 
-
-A breakdown of the tools we recommend for testing accessibility, including assistive technology, can be found on the Playbook [Accessibility tools](tools.md) page. 
+A breakdown of the tools we recommend for testing accessibility, including assistive technology, can be found on the Playbook [Accessibility tools](tools.md) page.

--- a/learning/README.md
+++ b/learning/README.md
@@ -1,0 +1,8 @@
+# Learning resources
+
+In this section we offer curated lists of learning resources that people can use to get started or improve their knowledge of accessibility or web performance.
+
+* [Accessibility](web-accessibility.md)
+* [Web performance](web-performance.md)
+
+[Main table of contents](../README.md#table-of-contents)

--- a/learning/web-accessibility.md
+++ b/learning/web-accessibility.md
@@ -1,0 +1,12 @@
+# Web accessibility
+
+This is a list of different resources that we offer to people interested in knowing more about web accessibility.
+
+Udacity have published an [excellent free course on Web Accessibility](https://www.udacity.com/course/web-accessibility--ud891) with Google engineers Alice Boxhall and Rob Dodson. 
+
+The Financial Times have produced an [accessibility tip sheet](https://ft-interactive.github.io/accessibility/index.html).
+
+The Government Digital Service frequently publishes excellent resources. Some highlights are:
+
+* [We're making accessibility clearer and easier](https://gds.blog.gov.uk/2017/10/23/were-making-accessibility-clearer-and-easier/)
+* [Making your service accessible: an introduction](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction)

--- a/learning/web-performance.md
+++ b/learning/web-performance.md
@@ -1,0 +1,31 @@
+# Web performance
+
+This is a list of different resources that we offer to people interested in knowing more about web performance.
+
+## Online courses
+
+For people wanting to learn about web performance we recommend to have a look at the following courses:
+
+* ["Lightning-fast web performance"](https://scottjehl.com/lfwp/) by Scott Jehl is an excellent short introductory course that has been recently made free.
+* ["Web Performance Fundamentals"](https://frontendmasters.com/courses/web-perf/) by Todd Gardner covers things in more detail. A subscription to Frontend Masters is required.
+
+## Books
+
+The following books can be used as refererence. Some of them have been published for a while so not all advice may be applicable today, but they are still very useful to improve knowledge of a particular subject.
+
+* "High Performance Web Sites" by Steve Souders: https://learning.oreilly.com/library/view/high-performance-web/9780596529307/
+* "Even Faster Web Sites" by Steve Souders: https://learning.oreilly.com/library/view/even-faster-web/9780596803773/
+* "High Performance Browser Networking" by Ilya Grigorik: https://hpbn.co/
+* "HTTP/2 in Action" by Barry Pollard: https://learning.oreilly.com/library/view/http-2-in-action/9781617295164/
+* "Using WebPageTest" by Rick Viscomi, Andy Davies & Marcel Duran: https://learning.oreilly.com/library/view/using-webpagetest/9781491902783/
+* "Time Is Money" by Tammy Everts: https://learning.oreilly.com/library/view/time-is-money/9781491928783/
+
+## Videos
+
+* Catchpoint frequently releases videos showcasing new features of WebPageTest, or Twitch streams of their performance auditing sessions:
+https://www.youtube.com/channel/UC5CqJ9V7cQddZDf1DKXcy7Q/featured
+* The London Web Performance Group has a youtube channel with most of their talks: https://www.youtube.com/user/ldnwebperf/videos
+
+## Other resources
+
+* Google has three collections of web performance-related material available on their web.dev site: https://web.dev/learn/#collections


### PR DESCRIPTION
Creates a new "learning" section in the playbook, with resources for a11y and webperf. The a11y resources have been extracted from the Introduction to accessibility document.

A lot of whitespace changes, feel free to ignore those!
https://github.com/springernature/frontend-playbook/pull/434/files?w=1