### PR TITLE
Direct people to skip link component in Elements

### DIFF
--- a/accessibility/accessibility-checklist.md
+++ b/accessibility/accessibility-checklist.md
@@ -48,6 +48,10 @@ To help them out you can add a "Skip Navigation" link to the top of each page wh
 
 The Elements Design System includes [https://elements.springernature.com/springernature/components/global-skip-link](a skip link implementation) that you can use in your own project(s). 
 
+Resources:
+
+* [Article: WebAIM's overview of Skip Navigation techniques](https://webaim.org/techniques/skipnav/)
+
 
 ### Declare a language attribute
 

--- a/accessibility/accessibility-checklist.md
+++ b/accessibility/accessibility-checklist.md
@@ -46,25 +46,7 @@ Not all users are able to easily navigate by landmarks. Multiple navigation link
 
 To help them out you can add a "Skip Navigation" link to the top of each page which, when activated, will take them to the main section of the page.
 
-We do this:
-
-```
-<body>
-<p><a href="#maincontent">Skip to main content</a></p>
-...
-<main id="maincontent" tabindex="-1">
-<h1>Heading</h1>
-<p>This is the first paragraph</p>
-```
-
-We add `tabindex="-1"` to the targeted element so that it can be programmatically focussed when skipped to.
-
-You should supply CSS that hides the Skip Navigation _for sighted users only_, and makes the link highly visible when it receives focus via tabbing.
-
-Resources:
-
-* [Article: WebAIM's overview of Skip Navigation techniques](https://webaim.org/techniques/skipnav/)
-* [Example: Springer Link's well-done skip navigation](https://link.springer.com)
+The Elements Design System includes [https://elements.springernature.com/springernature/components/global-skip-link](a skip link implementation) that you can use in your own project(s). 
 
 
 ### Declare a language attribute


### PR DESCRIPTION
The advice in the checklist is a little out of date - but the component in Elements is not. Instead of replicating the documentation from Elements, I've just removed the outdated advice and directed people to the design system instead, so we're not maintaining the info in two separate locations. 