### PR TITLE
Delete questionable CSS practice

### DIFF
--- a/css/house-style.md
+++ b/css/house-style.md
@@ -122,33 +122,6 @@ span {
 }
 ```
 
-**Items that semantically MUST sit within other items**. We do this:
-```scss
-ul {
-    > li {
-        display: inline;
-    }
-}
-
-dl {
-    > dt,
-    > dd {
-        display: inline-block;
-    }
-}
-
-table {
-    > tr {
-        > th {
-            background: #ccc;
-        }
-        > td {
-            background: #eee;
-        }
-    }
-}
-```
-
 **Javascript-only style enhancements**. We do this:
 ```scss
 .c-class {


### PR DESCRIPTION
In the same [document](https://github.com/springernature/frontend-playbook/blob/8d09fc5a25a738c75d53aeba0f9d28f0db8ff69d/css/house-style.md), we explain that we should prefer a class over HTML tags (with some exceptions - which are not explained) and then show how we nest HTML tags, where still classes would do.

Also, the example to me doesn't make any sense - in the proposed case when items semantically must sit within other items, then why nest them in CSS rules? If a `<td>` must sit within a `<tr>` and that within a `<table>`, then why not directly style the `<td>`?

If these rules make sense, then I am not getting it and that _might_ be an indicator that some more detailed documentation could help here.

So I want to put this section up for discussion.

The only possibly useful nesting here I can see would be the `ul > li` one, as it explicitly differs from an `<li>` nested within an `<ol>`, even though I still would propose that a class would make more sense here, like for example `.c-inline-list > li`.