### PR TITLE
Removes Twitter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,4 @@ Because of this, it is fine (in many cases highly _desired_) to propose somethin
 
 A bot notifies the #frontend Slack room when work is merged, because changes to the playbook are relevant to all Frontend developers at Springer Nature.
 
-We hope the wider development community will be interested in the work we have committed here. We welcome feedback and involvement from all - so feel free to link to your latest contribution on Twitter, or your social media platform of choice.
+We hope the wider development community will be interested in the work we have committed here. We welcome feedback and involvement from all - so feel free to link to your latest contribution on your social media platform of choice.

--- a/javascript/house-style.md
+++ b/javascript/house-style.md
@@ -269,7 +269,7 @@ ajax('https://example.com').then(response => response.url).then(url => {
 })
 ```
 
-Promises still use callbacks. To write synchronous-style code which performs asynchronous operations, you can use [async/await](https://twitter.com/addyosmani/status/756204943527129090). The above example can be rewritten to use `async/await`.
+Promises still use callbacks. To write synchronous-style code which performs asynchronous operations, you can use [async/await](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Promises#async_and_await). The above example can be rewritten to use `async/await`.
 
 ```js
 const {url} = await ajax('https://example.com');

--- a/security/secure-markup.md
+++ b/security/secure-markup.md
@@ -28,7 +28,7 @@ Ideally this should be specified in both the HTTP header and a `meta` element, i
 
 Links leak the context of the opening window to the opened window, via the `window.opener` object. This allows the opened window to alter the opening window via JavaScript, regardless of whether the window is opened via JavaScript or simply a `target="_blank"` attribute. Exploiting this [context leaking is a security problem](https://mathiasbynens.github.io/rel-noopener/).
 
-As of 2023, recent versions of all major browsers treat `target=_blank` links as `noopener` by default. However, we still recommend including this attribute because as an HTML feature it will be served to older browsers, and is cheap to implement.
+As of 2020, recent versions of all major browsers treat `target=_blank` links as `noopener` by default. However, we still recommend including this attribute because as an HTML feature it will be served to older browsers, and is cheap to implement.
 
 ## Use Subresource Integrity
 

--- a/security/secure-markup.md
+++ b/security/secure-markup.md
@@ -2,7 +2,6 @@
 
   * [Scope of this document](#scope-of-this-document)
   * [Use UTF-8 and specify this in a `meta` tag](#use-utf-8-and-specify-this-in-a-meta-tag)
-  * [Add `rel="noopener"` to outbound links in new windows](#add-relnoopener-to-outbound-links-in-new-windows)
   * [Use Subresource Integrity](#use-subresource-integrity)
   * [Use sane form defaults](#use-sane-form-defaults)
     + [A note on autofill](#a-note-on-autofill)
@@ -23,12 +22,6 @@ Do this: `<meta charset="utf-8">`.
 Not specifying the appropriate character set has historically been a source of [charset-related security problems](https://code.google.com/archive/p/doctype-mirror/wikis/ArticleUtf7.wiki) as well as a source of rendering bugs.
 
 Ideally this should be specified in both the HTTP header and a `meta` element, in case one breaks.
-
-## Add `rel="noopener"` to outbound links in new windows
-
-Links leak the context of the opening window to the opened window, via the `window.opener` object. This allows the opened window to alter the opening window via JavaScript, regardless of whether the window is opened via JavaScript or simply a `target="_blank"` attribute. Exploiting this context leaking is known as ["tabnabbing"](https://mathiasbynens.github.io/rel-noopener/).
-
-**Nov 2020 update**: [Chrome 88+](https://chromium-review.googlesource.com/c/chromium/src/+/1630010) will match Safari and Firefox's behavior of treating `target=_blank` links as `noopener` by default (thanks [@mikewest](https://twitter.com/mikewest/status/1325694207546318851)). However, we still recommend including this attribute at this time in line with our browser support policy.
 
 ## Use Subresource Integrity
 

--- a/security/secure-markup.md
+++ b/security/secure-markup.md
@@ -2,6 +2,7 @@
 
   * [Scope of this document](#scope-of-this-document)
   * [Use UTF-8 and specify this in a `meta` tag](#use-utf-8-and-specify-this-in-a-meta-tag)
+  * [Add `rel="noopener"` to outbound links in new windows](#add-relnoopener-to-outbound-links-in-new-windows)
   * [Use Subresource Integrity](#use-subresource-integrity)
   * [Use sane form defaults](#use-sane-form-defaults)
     + [A note on autofill](#a-note-on-autofill)
@@ -22,6 +23,12 @@ Do this: `<meta charset="utf-8">`.
 Not specifying the appropriate character set has historically been a source of [charset-related security problems](https://code.google.com/archive/p/doctype-mirror/wikis/ArticleUtf7.wiki) as well as a source of rendering bugs.
 
 Ideally this should be specified in both the HTTP header and a `meta` element, in case one breaks.
+
+## Add `rel="noopener"` to outbound links in new windows
+
+Links leak the context of the opening window to the opened window, via the `window.opener` object. This allows the opened window to alter the opening window via JavaScript, regardless of whether the window is opened via JavaScript or simply a `target="_blank"` attribute. Exploiting this [context leaking is a security problem](https://mathiasbynens.github.io/rel-noopener/).
+
+As of 2023, recent versions of all major browsers treat `target=_blank` links as `noopener` by default. However, we still recommend including this attribute because as an HTML feature it will be served to older browsers, and is cheap to implement.
 
 ## Use Subresource Integrity
 

--- a/writing/inclusive-language.md
+++ b/writing/inclusive-language.md
@@ -28,7 +28,7 @@ Stereotyping means presuming a range of things about people based on their perso
 
 Language matters. It remains a common practice in IT to use terminology like slave/master or blacklist/whitelist that reference slavery or segregation.
 
-There's always a better way to label the relationship between two entities. In the case of databases, choosing more descriptive terms like replica/primary, secondary/primary, follower/leader or standby/active instead of slave/master not only removes the reference to slavery, but also [makes it easier to understand](https://twitter.com/geeksam/status/1038081079641395201) for people not familiar with the terminology.
+There's always a better way to label the relationship between two entities. In the case of databases, choosing more descriptive terms like replica/primary, secondary/primary, follower/leader or standby/active instead of slave/master not only removes the reference to slavery, but also makes it easier to understand for people not familiar with the terminology.
 
 Similarly, in the case of blacklist/whitelist there are alternatives that better show their purpose to people not familiar with the terminology, like denylist/allowlist, blocklist/allowlist or block/permit. Choose a term that is appropriate and descriptive for your particular app or feature.
 

--- a/writing/inclusive-language.md
+++ b/writing/inclusive-language.md
@@ -28,7 +28,7 @@ Stereotyping means presuming a range of things about people based on their perso
 
 Language matters. It remains a common practice in IT to use terminology like slave/master or blacklist/whitelist that reference slavery or segregation.
 
-There's always a better way to label the relationship between two entities. In the case of databases, choosing more descriptive terms like replica/primary, secondary/primary, follower/leader or standby/active instead of slave/master not only removes the reference to slavery, but also makes it easier to understand for people not familiar with the terminology.
+There's always a better way to label the relationship between two entities. In the case of databases, choosing more descriptive terms like replica/primary, secondary/primary, follower/leader or standby/active instead of slave/master not only removes the reference to slavery, but also makes it easier to understand as it [avoids metaphor](https://github.com/springernature/frontend-playbook/blob/main/writing/house-style.md#plain-english).
 
 Similarly, in the case of blacklist/whitelist there are alternatives that better show their purpose to people not familiar with the terminology, like denylist/allowlist, blocklist/allowlist or block/permit. Choose a term that is appropriate and descriptive for your particular app or feature.
 

--- a/writing/social-media.md
+++ b/writing/social-media.md
@@ -11,8 +11,6 @@ For open-source projects, we aim to keep our projects up to date and fix any vul
 
 [Cruft.io](http://cruft.io) is a blog run by a group of developers, testers, sysadmins, scrum masters and product owners at Springer Nature. Anyone can post there and the instructions can be found in the [project's wiki (internal)](https://github.com/springernature/cruft/).
 
-Cruft has also a [@cruftio Twitter account](https://twitter.com/cruftio) that is used to promote its blog posts. We're also using @cruftio to promote the release of new versions of our open-source projects.
-
 ## Posting publicly
 
 Before publishing anything ensure that:

--- a/writing/social-media.md
+++ b/writing/social-media.md
@@ -9,7 +9,7 @@ For open-source projects, we aim to keep our projects up to date and fix any vul
 
 ## Cruft.io
 
-[Cruft.io](http://cruft.io) is a blog run by a group of developers, testers, sysadmins, scrum masters and product owners at Springer Nature. Anyone can post there and the instructions can be found in the [project's wiki (internal)](https://github.com/springernature/cruft/).
+[Cruft.io](http://cruft.io) is a blog run by Springer Nature Technology. Anyone can post there and the instructions can be found in the [project's wiki (internal)](https://github.com/springernature/cruft/).
 
 ## Posting publicly
 


### PR DESCRIPTION
This PR is intended to remove all references to Twitter from the playbook for a variety of reasons:

`CONTRIBUTING.md`
I do not feel that the promotion of content on Twitter is in line with our inclusive practices.

`javascript/house-style.md`
Links to Twitter are starting to disappear as accounts close due to declining Twitter usage in the tech community, so I suggest replacing this link to a tweet with a fuller (and probably more permanent) link to an introduction to `async/await` on MDN.

`security/secure-markup.md`
  - Usage of the phrase ["tabnabbing"](https://en.wikipedia.org/wiki/Tabnabbing) is not consistent, and has appeared to evolve since the time of writing.
  - Updated advisory on usage.

`writing/inclusive-language.md`
Link dead.

`writing/social-media.md`
We will not be continuing to use Twitter to promote Cruft posts. We can update as and when we decide on an alternative platform to use.