### PR TITLE
Add link to the eight landmark roles 

### DIFF
--- a/accessibility/accessibility-checklist.md
+++ b/accessibility/accessibility-checklist.md
@@ -27,7 +27,7 @@ Resources:
 
 Assistive technology may make use of ARIA landmark roles or HTML5 landmark elements for navigation. These allow users to quickly jump between page sections.
 
-There are 8 landmark roles. Most browsers implicitly detect these roles if you use the correct HTML5 semantic element, but you may need to add the appropriate ARIA `role=` if you have to support an [older browser](http://www.html5accessibility.com/#sections).
+There are [8 landmark roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles). Most browsers implicitly detect these roles if you use the correct HTML5 semantic element, but you may need to add the appropriate ARIA `role=` if you have to support an older browser.
 
 If you use more than one landmark of the same type, give each landmark a unique label so that screen reader users can tell them apart easily.
 


### PR DESCRIPTION
Replaced http://www.html5accessibility.com/#sections which was referencing HTML sectioning elements instead of landmarks with https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#3._landmark_roles. 