### PR TITLE
Replace SASS with Sass

### DIFF
--- a/css/house-style.md
+++ b/css/house-style.md
@@ -90,7 +90,7 @@ Static analysis tools like linters can flag programming errors, bugs and stylist
 CSS code (not compiled) should be linted with [styleLint](https://github.com/stylelint/stylelint). You can find _an example_ config file in the [config directory](config).
 
 Sass code should be linted with [Stylelint](https://stylelint.io/) using the [Springer Nature
-`sasslint-config`](https://github.com/springernature/sasslint-config-springernature). This configuration allows us to maintain consistency between different projects.
+`stylelint-config`](https://github.com/springernature/stylelint-config-springernature). This configuration allows us to maintain consistency between different projects.
 
 You can check the [README](https://github.com/springernature/sasslint-config-springernature/blob/main/README.md) for details about installing and configuring the tools.
 

--- a/css/house-style.md
+++ b/css/house-style.md
@@ -89,14 +89,14 @@ Static analysis tools like linters can flag programming errors, bugs and stylist
 
 CSS code (not compiled) should be linted with [styleLint](https://github.com/stylelint/stylelint). You can find _an example_ config file in the [config directory](config).
 
-SASS code should be linted with [sass-lint](https://github.com/sasstools/sass-lint) using the [Springer Nature
+Sass code should be linted with [sass-lint](https://github.com/sasstools/sass-lint) using the [Springer Nature
 `sasslint-config`](https://github.com/springernature/sasslint-config-springernature). This configuration allows us to maintain consistency between different projects.
 
 You can check the [README](https://github.com/springernature/sasslint-config-springernature/blob/main/README.md) for details about installing and configuring the tools.
 
 ## Preprocessors
 
-Our preferred CSS preprocessor is [SASS](http://sass-lang.com/) using the [SCSS syntax](http://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html).
+Our preferred CSS preprocessor is [Sass using the SCSS syntax](how-we-write-css.md).
 
 ### Nesting
 

--- a/css/house-style.md
+++ b/css/house-style.md
@@ -96,7 +96,7 @@ You can check the [README](https://github.com/springernature/sasslint-config-spr
 
 ## Preprocessors
 
-Our preferred CSS preprocessor is [Sass using the SCSS syntax](how-we-write-css.md).
+Our preferred CSS preprocessor is [Sass](https://sass-lang.com) using the SCSS syntax. Find out about [how we write CSS](how-we-write-css.md).
 
 ### Nesting
 

--- a/css/house-style.md
+++ b/css/house-style.md
@@ -89,7 +89,7 @@ Static analysis tools like linters can flag programming errors, bugs and stylist
 
 CSS code (not compiled) should be linted with [styleLint](https://github.com/stylelint/stylelint). You can find _an example_ config file in the [config directory](config).
 
-Sass code should be linted with [sass-lint](https://github.com/sasstools/sass-lint) using the [Springer Nature
+Sass code should be linted with [Stylelint](https://stylelint.io/) using the [Springer Nature
 `sasslint-config`](https://github.com/springernature/sasslint-config-springernature). This configuration allows us to maintain consistency between different projects.
 
 You can check the [README](https://github.com/springernature/sasslint-config-springernature/blob/main/README.md) for details about installing and configuring the tools.

--- a/css/how-we-write-css.md
+++ b/css/how-we-write-css.md
@@ -2,15 +2,15 @@
 
 Our approach to writing CSS aims to provide a framework for working that allows individual teams the flexibility to make project appropriate decisions within a company wide structure. By following a consistent approach across teams we aim to make it easier to move developers around and allow for the easy evolution of our approach within a large company.
 
-We advocate a componentised approach that is designed for scale, is based on [SASS](http://sass-lang.com/) (using the [SCSS](http://sass-lang.com/documentation/file.SCSS_FOR_SASS_USERS.html) syntax), follows the [BEM Methodology](bem-css.md), and borrows elements from [OOCSS](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/), Utility Classes, and [ITCSS](http://itcss.io/).
+We advocate a componentised approach that is designed for scale, is based on [Sass](https://sass-lang.com/) (using the [SCSS](https://sass-lang.com/documentation/syntax/#scss) syntax), follows the [BEM Methodology](bem-css.md), and borrows elements from [OOCSS](https://www.smashingmagazine.com/2011/12/an-introduction-to-object-oriented-css-oocss/), Utility Classes, and [ITCSS](https://itcss.io/).
 
 Any CSS that we write should conform to our [house style](house-style.md).
 
 ## Architecture
 
-The architecture is split into a series of **levels** with each level representing a folder that contains our SASS split out into different files. Where applicable, content can be organised into sub-folders.
+The architecture is split into a series of **levels** with each level representing a folder that contains our Sass split out into different files. Where applicable, content can be organised into sub-folders.
 
-We follow some of the principles of ITCSS - this means that the CSS is organised in specificity order and the SASS files should be included in the order denoted by this structure.
+We follow some of the principles of ITCSS - this means that the CSS is organised in specificity order and the Sass files should be included in the order denoted by this structure.
 
 The lower the level number the more generic the styles, the higher the number the more explicit. As the levels increase, so does the specificity. If a level is not needed, it can be excluded. At a product level we may need to add levels into the stack.
 
@@ -19,13 +19,13 @@ The lower the level number the more generic the styles, the higher the number th
 A summary of the different levels and their purpose:
 
 #### Settings
-Contains all **global** SASS variables ([see Sass naming](https://github.com/springernature/frontend-playbook/blob/main/css/how-we-write-css.md#sass-variable-naming)) for your project e.g. colors, fonts, media queries.
+Contains all **global** Sass variables ([see Sass naming](https://github.com/springernature/frontend-playbook/blob/main/css/how-we-write-css.md#sass-variable-naming)) for your project e.g. colors, fonts, media queries.
 
 #### Functions
-Contains all **global** SASS functions e.g. em calculation, unit stripping.
+Contains all **global** Sass functions e.g. em calculation, unit stripping.
 
 #### Mixins
-Contains all **global** SASS mixins, this includes mixin definitions used in the **component** and **utility** levels.
+Contains all **global** Sass mixins, this includes mixin definitions used in the **component** and **utility** levels.
 
 #### Base
 A Base rule is applied to an element using an element/type selector, a descendant selector, or a child selector, along with any pseudo-classes. Base styles are related to the basic styles of your product, like typography, reset and global elements like links. Use this level to include any (third-party) resets or normalization css.


### PR DESCRIPTION
Apparently, the sass' developers preferred way of writing SASS is Sass.

Also replace a URL that was being redirected with the canonical one, and add a couple of 'S' to a couple of 'HTTP'.