### PR TITLE
Update practices and cleanup of the Performance section

### DIFF
--- a/performance/README.md
+++ b/performance/README.md
@@ -4,9 +4,10 @@ Performance refers to the speed in which web pages are downloaded and displayed 
 
 Faster page speeds have been shown to increase visitor retention and user satisfaction, especially for users with slow internet connections and those on mobile devices. Improved web performance also leads to less data travelling across the web, which in turn lowers a website's power consumption and environmental impact.
 
-* [Advertising](advertising.md)
-* [Browser Caching](browser-caching.md)
-* [Font Loading](font-loading.md)
-* [Images](images.md)
+- [Advertising](advertising.md)
+- [Browser caching](browser-caching.md)
+- [Font loading](font-loading.md)
+- [Images](images.md)
+- [Performance checklist](performance-checklist.md)
 
 [Main table of contents](../README.md#table-of-contents)

--- a/performance/advertising.md
+++ b/performance/advertising.md
@@ -1,9 +1,9 @@
 # Advertising
 
-* [Ethical](#ethical)
-* [Accessibility](#accessibility)
-* [Performance](#performance)
-* [References](#references)
+- [Ethical](#ethical)
+- [Accessibility](#accessibility)
+- [Performance](#performance)
+- [References](#references)
 
 These guidelines are based on ethical, [accessibility](../accessibility/introduction.md) and performance recommendations and best practices.
 

--- a/performance/browser-caching.md
+++ b/performance/browser-caching.md
@@ -1,4 +1,9 @@
-# Browser Caching
+# Browser caching
+
+- [HTML Markup](#html-markup)
+- [CSS, JS and Images](#css-js-and-images)
+- [General](#general)
+- [Further resources](#further-resources)
 
 ## HTML Markup
 
@@ -13,8 +18,8 @@
 ## General
 
 * If it is under your control, ensure the server provides an Entity Tag (`ETag`) header. The `ETag` header is an additional identifier for a specific version of a resource, typically comprised of the modified time and file size. (On older systems the ETag may also include an inode portion, but this is problematic.) The `Etag` header is especially useful to prevent simultaneous updates overwriting each other. If you use a CDN, it is likely this header will already be provided and properly configured. Learn more:
-    * [MDN ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
-    * [Express options for 'ETag' setting](https://expressjs.com/en/api.html#etag.options.table)
+  * [MDN ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag)
+  * [Express options for 'ETag' setting](https://expressjs.com/en/api.html#etag.options.table)
 * You no longer need to use [`Expires` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expires) as it has been superseded by `Cache-Control` header with `max-age`, which is [supported by modern browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Browser_compatibility).
 
 It’s important to note that there isn’t a one-size-fits-all approach to caching, so always decide a caching strategy based on your needs.

--- a/performance/font-loading.md
+++ b/performance/font-loading.md
@@ -1,4 +1,15 @@
-# Font Loading
+# Font loading
+
+- [When to use webfonts](#when-to-use-webfonts)
+- [Implementation](#implementation)
+- [Quick tips](#quick-tips)
+  - [Understand the different user experiences in font loading: FOIT, FOUT and FOFT](#understand-the-different-user-experiences-in-font-loading-foit-fout-and-foft)
+  - [Understand the different implementations available](#understand-the-different-implementations-available)
+  - [WOFF and WOFF2 font formats](#woff-and-woff2-font-formats)
+  - [font-display CSS](#font-display-css)
+  - [Loading fonts with JavaScript](#loading-fonts-with-javascript)
+  - [Preloading webfonts](#preloading-webfonts)
+  - [Self host webfonts if possible](#self-host-webfonts-if-possible)
 
 ## When to use webfonts
 
@@ -25,9 +36,10 @@ We do not prescribe a particular implementation. Each team should determine whic
 - [Progressive Enhancement](https://github.com/springernature/frontend-playbook/blob/main/practices/progressive-enhancement.md)
   - This is not meant to force you to choose a non-js implementation, but rather for you to ensure you consider what will happen for users in varying circumstances from the beginning.
 - [Our Performance Goals](https://github.com/springernature/frontend-playbook/blob/main/performance/performance-checklist.md)
-  - What impact will the implementation have on the page performance of your site? 
-  
-## Quick Tips
+  - What impact will the implementation have on the page performance of your site?
+
+## Quick tips
+
 Here are some quick suggestions for techniques that may prove useful:
 
 ### Understand the different user experiences in font loading: FOIT, FOUT and FOFT
@@ -42,9 +54,9 @@ We believe that FOIT should be avoided as it is the worst experience for the use
 
 We highly recommend reading [Zach Leat's comprehensive guide](https://www.zachleat.com/web/comprehensive-webfonts/) to get a good understanding of the different techniques available. There is also a good [follow-up article](https://css-tricks.com/the-best-font-loading-strategies-and-how-to-execute-them/) that summarises Zach's findings.
 
-### Serve WOFF and WOFF2 font formats
+### WOFF and WOFF2 font formats
 
-WOFF2 has the superior compression. However, unfortunately [it does not cover all of our Enhanced browsers](https://caniuse.com/woff2) at the time of writing. Therefore consider serving both formats. 
+WOFF2 has a superior compression, and [is supported by all of our Enhanced browsers](https://caniuse.com/woff2), so there's no need to serve fonts in WOFF format.
 
 ### [font-display CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display)
 
@@ -58,7 +70,7 @@ Consider using [FontFaceObserver](https://github.com/bramstein/fontfaceobserver)
 
 ### Preloading webfonts
 
-If you have to load a font the conventional way using a `<link>` then consider using the [preload technique](https://web.dev/preload-critical-assets/) to ensure the font is requested as early on in the page load process as possible. 
+If you have to load a font the conventional way using a `<link>` then consider using the [preload technique](https://web.dev/preload-critical-assets/) to ensure the font is requested as early on in the page load process as possible.
 
 `<link rel="preload" href="HardingText-Regular-Web.woff2" as="font" type="font/woff2" crossorigin>`
 

--- a/performance/images.md
+++ b/performance/images.md
@@ -32,7 +32,7 @@ Most best practices described in this document apply to both categories unless o
 
 A number of more modern image formats can also be used to deliver images:
 
-* [WebP](https://en.wikipedia.org/wiki/WebP) is a replacement for JPEG, PNG, and GIFs, but improvements to encoders like [mozjpeg](https://github.com/mozilla/mozjpeg) means that [WEBP file sizes are only marginally smaller than JPEG](https://siipo.la/blog/is-webp-really-better-than-jpeg). It's supported by almost all major browsers ([Safari supports it partially](https://caniuse.com/webp)) and can be used only as an enhancement to another better supported format.
+* [WebP](https://en.wikipedia.org/wiki/WebP) is a replacement for JPEG, PNG, and GIFs, but improvements to encoders like [mozjpeg](https://github.com/mozilla/mozjpeg) means that [WEBP file sizes are only marginally smaller than JPEG](https://siipo.la/blog/is-webp-really-better-than-jpeg). It's supported by almost all major browsers ([Safari supports it partially](https://caniuse.com/webp)) and must be used only as an enhancement to another better supported format.
 * [AVIF](https://en.wikipedia.org/wiki/AVIF) is suitable for static and animated images, and supports both lossy and lossless compression with better compression efficiency and better detail preservation than other formats. It's [supported by Chrome and Firefox](https://caniuse.com/avif), and can be used only as an enhancement to another better supported format. Compression (encoding) of images can be significantly slower than with other formats.
 * [JPEG-XL](https://en.wikipedia.org/wiki/JPEG_XL) supports both lossy and lossless compression. It's [more efficient than other formats while being usually faster](https://cloudinary.com/blog/how_jpeg_xl_compares_to_other_image_codecs) both when compressing and decompressing than JPEG. Unfortunately, as of November 2022 [no browser officially supports it](https://caniuse.com/jpegxl) and [Google has announced that it's removing preliminary support from Chrome](https://www.theregister.com/2022/10/31/jpeg_xl_axed_chrome/), in favour of AVIF.
 
@@ -47,7 +47,7 @@ Always minify your SVGs using [SVGO](https://github.com/svg/svgo) or a similar t
 When encoding JPEG images:
 
 * Use progressive encoding. [Progressive JPEGs provide a better user experience and, most of the time, are smaller than baseline](https://github.com/yeoman/yeoman/issues/810).
-* Use [4:2:0](https://en.wikipedia.org/wiki/Chroma_subsampling#4:2:0) [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling) whenever possible. This encodes the colour information at half the resolution of the luma usually generating smaller images. It may however result in a perceptible loss of colour accuracy, so we suggest to create both 4:4:4 and 4:2:0 versions of an image and compare them for any quality loss. See [Comparing the quality of images](#comparing-the-quality-of-images) below for tools that can help you with this.
+* Use [4:2:0](https://en.wikipedia.org/wiki/Chroma_subsampling#4:2:0) [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling) whenever possible. This encodes the colour information at half the resolution of the luma, usually generating smaller images. It may however result in a perceptible loss of colour accuracy, so we suggest to create both 4:4:4 and 4:2:0 versions of an image and compare them for any quality loss. See [Comparing the quality of images](#comparing-the-quality-of-images) below for tools that can help you with this.
 * Use encoders like [Mozilla's mozjpeg](https://github.com/mozilla/mozjpeg) that can create images with the same visual quality as other encoders but a much smaller file size.
 
 ### PNG images
@@ -81,7 +81,7 @@ For content images, we encourage using an on-premise or cloud-based image server
 * Ensure that all images are optimised automatically.
 * Ensure that the appropriate cache headers are always set.
 
-As an additional benefit, future improvements to these tools may result in improvements to the images being served automatically, without the images having to be manually re-encoded.
+As an additional benefit, changes to these tools may result in improvements to the images being served automatically, without the images having to be manually re-encoded.
 
 ## Comparing the quality of images
 

--- a/performance/images.md
+++ b/performance/images.md
@@ -1,14 +1,14 @@
 # Images
 
-* [Introduction](#introduction)
-* [Picking the right image format](#picking-the-right-image-format)
-* [Image formats](#image-formats)
-  * [SVG images](#svg-images)
-  * [JPEG images](#jpeg-images)
-  * [PNG images](#png-images)
-* [Optimisation of images](#optimisation-of-images)
-* [Serving images](#serving-images)
-* [Comparing the quality of images](#comparing-the-quality-of-images)
+- [Introduction](#introduction)
+- [Picking the right image format](#picking-the-right-image-format)
+- [Image formats](#image-formats)
+  - [SVG images](#svg-images)
+  - [JPEG images](#jpeg-images)
+  - [PNG images](#png-images)
+- [Optimisation of images](#optimisation-of-images)
+- [Serving images](#serving-images)
+- [Comparing the quality of images](#comparing-the-quality-of-images)
 
 This document describes best practices for the use of images on the web at Springer Nature.
 
@@ -32,10 +32,9 @@ Most best practices described in this document apply to both categories unless o
 
 A number of more modern image formats can also be used to deliver images:
 
-* [WEBP](https://en.wikipedia.org/wiki/WebP) is a replacement for JPEG, PNG, and GIFs, but improvements to encoders like mozjpeg means that WEBP file sizes are only marginally smaller than JPEG. It's supported by almost all major browsers ([Safari supports it partially](https://caniuse.com/webp)) and can be used only as an enhancement to another better supported format.
+* [WebP](https://en.wikipedia.org/wiki/WebP) is a replacement for JPEG, PNG, and GIFs, but improvements to encoders like [mozjpeg](https://github.com/mozilla/mozjpeg) means that [WEBP file sizes are only marginally smaller than JPEG](https://siipo.la/blog/is-webp-really-better-than-jpeg). It's supported by almost all major browsers ([Safari supports it partially](https://caniuse.com/webp)) and can be used only as an enhancement to another better supported format.
 * [AVIF](https://en.wikipedia.org/wiki/AVIF) is suitable for static and animated images, and supports both lossy and lossless compression with better compression efficiency and better detail preservation than other formats. It's [supported by Chrome and Firefox](https://caniuse.com/avif), and can be used only as an enhancement to another better supported format. Compression (encoding) of images can be significantly slower than with other formats.
-* [JPEG-XL](https://en.wikipedia.org/wiki/JPEG_XL) supports both lossy and lossless compression. It's [more efficient than other formats while being usually faster](https://cloudinary.com/blog/how_jpeg_xl_compares_to_other_image_codecs
-) both when compressing and decompressing than JPEG. Unfortunately, as of November 2022 [no browser officially supports it](https://caniuse.com/jpegxl) and [Google has announced that it's removing preliminary support from Chrome](https://www.theregister.com/2022/10/31/jpeg_xl_axed_chrome/), in favour of AVIF.
+* [JPEG-XL](https://en.wikipedia.org/wiki/JPEG_XL) supports both lossy and lossless compression. It's [more efficient than other formats while being usually faster](https://cloudinary.com/blog/how_jpeg_xl_compares_to_other_image_codecs) both when compressing and decompressing than JPEG. Unfortunately, as of November 2022 [no browser officially supports it](https://caniuse.com/jpegxl) and [Google has announced that it's removing preliminary support from Chrome](https://www.theregister.com/2022/10/31/jpeg_xl_axed_chrome/), in favour of AVIF.
 
 ## Image formats
 
@@ -47,8 +46,8 @@ Always minify your SVGs using [SVGO](https://github.com/svg/svgo) or a similar t
 
 When encoding JPEG images:
 
-* Use progressive encoding. Progressive JPEGs provide a better user experience and, most of the time, are smaller than baseline. See this [yeoman issue](https://github.com/yeoman/yeoman/issues/810) for further details.
-* Use [4:2:0](https://en.wikipedia.org/wiki/Chroma_subsampling#4:2:0) [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling) whenever possible. This encodes the colour information at half the resolution of the luma, which may result in a perceptible loss of colour accuracy. This will usually generate much smaller images, so we suggest to create both of them and compare them for any loss of quality. For tools that can help you with this, see: [Comparing the quality of images](#comparing-the-quality-of-images), below.
+* Use progressive encoding. [Progressive JPEGs provide a better user experience and, most of the time, are smaller than baseline](https://github.com/yeoman/yeoman/issues/810).
+* Use [4:2:0](https://en.wikipedia.org/wiki/Chroma_subsampling#4:2:0) [chroma subsampling](https://en.wikipedia.org/wiki/Chroma_subsampling) whenever possible. This encodes the colour information at half the resolution of the luma usually generating smaller images. It may however result in a perceptible loss of colour accuracy, so we suggest to create both 4:4:4 and 4:2:0 versions of an image and compare them for any quality loss. See [Comparing the quality of images](#comparing-the-quality-of-images) below for tools that can help you with this.
 * Use encoders like [Mozilla's mozjpeg](https://github.com/mozilla/mozjpeg) that can create images with the same visual quality as other encoders but a much smaller file size.
 
 ### PNG images
@@ -57,17 +56,17 @@ Always use the maximum compression level (9).
 
 ## Optimisation of images
 
-Images can contribute significantly to a page's size, so it's important to optimise them before they are delivered to the user. This helps ensure that our sites stay performant and we're not preventing anyone from accessing them due to increased page weight. Common optimisations include:
+Images can contribute significantly to the size of a page, so it's important to optimise them before they are delivered to the user. This helps ensure that our sites stay performant and we're not preventing anyone from accessing them due to increased page weight. Common optimisations include:
 
 * Making sure that you save images using an [sRGB](https://en.wikipedia.org/wiki/SRGB) ICC profile. Although modern browsers support images with ICCv2 profiles like [Adobe RGB](https://en.wikipedia.org/wiki/Adobe_RGB_color_space) and even [ProPhoto RGB](https://en.wikipedia.org/wiki/ProPhoto_RGB_color_space), colour space issues are extremely difficult to debug. Saving the images as sRGB and removing the colour profile is encouraged.
 * Stripping the metadata from the image. This includes things like EXIF data, Copyright information (unless required), GPS data, colour profiles, thumbnails (in JPEGs), comments, and others.
-* Setting appropriate cache headers for the images. (See [Serving images](#serving-images), below.)
+* [Setting appropriate cache headers for the images](#serving-images).
 
 For images that are going to be included in a repository, tools like [ImageOptim](https://imageoptim.com/mac) can be used to optimise them and strip the metadata before committing them to your codebase. There's also an [ImageOptim-CLI](https://github.com/JamieMason/ImageOptim-CLI) that can be integrated with CI systems.
 
 If an image is still too big after following all these optimisations, other options can be used that will require editing the image. These can be used to generate images with a much smaller size than otherwise would be possible:
 
-* Reducing noise or eliminating noise and other complexity from the image, which makes it easier to compress.
+* Reducing or completely eliminating noise and other complexity from the image, which makes it easier to compress.
 * Blurring unimportant areas will also make the image easier to compress.
 * Finally, decreasing the export quality may be required if the image is still too big.
 
@@ -82,7 +81,7 @@ For content images, we encourage using an on-premise or cloud-based image server
 * Ensure that all images are optimised automatically.
 * Ensure that the appropriate cache headers are always set.
 
-Additionally, future improvements to these tools will result in improvements to the images being served automatically, without the images having to be manually re-encoded.
+As an additional benefit, future improvements to these tools may result in improvements to the images being served automatically, without the images having to be manually re-encoded.
 
 ## Comparing the quality of images
 

--- a/performance/performance-checklist.md
+++ b/performance/performance-checklist.md
@@ -6,12 +6,20 @@ This checklist aims to help you and your team create performant products.
 
 Remember that, for most of these rules, there's always the chance that following them may impact performance in a negative way. Always use [any of the tools below](#tooling) to run before/after comparisons.
 
+- [HTTP Requests](#http-requests)
+- [Page weight](#page-weight)
+- [Render blocking resources](#render-blocking-resources)
+- [The critical rendering path](#the-critical-rendering-path)
+- [Post launch](#post-launch)
+- [Tooling](#tooling)
+- [Further resources](#further-resources)
+
 ## HTTP Requests
 
 A lower number of requests is directly related to better performance and higher user engagement. Make sure that the [number of HTTP requests is as small as possible](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch03.html) by:
 
 * Ensuring that there are [no redirects](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch13.html) on the page itself or in any of the first party resources.
-* Concatenating first party CSS and JS, when suitable. This is true even when using HTTP2.
+* Concatenating first party CSS and JS, when suitable. **This is true even when using HTTP2**.
 * Ensuring that no first party resources are returning HTTP 4xx or 5xx errors.
 * Serve first party resources from as few different domains as possible in order to [reduce DNS lookups](https://www.oreilly.com/library/view/high-performance-web/9780596529307/ch11.html).
 
@@ -20,14 +28,14 @@ A lower number of requests is directly related to better performance and higher 
 Another important factor that impacts user engagement is [the size of the resources](https://blog.chriszacharias.com/page-weight-matters). On low performing networks or devices, the size of the resources being loaded can delay the loading of the page by several seconds and increase power consumption significantly.
 
 * [Minify all text resources](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch12.html) over 1500 bytes.
-* Ensure that all text resources over 1500 bytes use Brotli, Zopfli or [GZip compression](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch06.html).
+* Ensure that all text resources over 1500 bytes use Brotli or [GZip compression](https://learning.oreilly.com/library/view/high-performance-web/9780596529307/ch06.html).
 * [Choose the right format for images, and optimise images and SVGs](images.md).
 * Set an [appropriate expiry date or a maximum age](browser-caching.md#css-js-and-images) for all static resources.
 * For resources that change rarely, consider [fingerprinting them](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching) and setting a expiry date [far in the future](https://developers.google.com/web/tools/lighthouse/audits/cache-policy).
 
 ## Render blocking resources
 
-CSS and JS resources can be [render blocking](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources) as the browser will pause rendering of a page while a CSS file or a synchronous JS file or script are being loaded. On slow connections this can delay the page load by several seconds. Ensure there are as few render blocking resources as possible by:
+CSS and JS resources can be [render blocking](https://developers.google.com/web/tools/lighthouse/audits/blocking-resources), meaning that the browser will pause rendering of a page while a CSS file or a synchronous JS file or script are being loaded. On slow connections this can delay the page load by several seconds. Ensure there are as few render blocking resources as possible by:
 
 * Using [`async` or, when possible, `defer` attributes](https://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html) in all JavaScript files.
 * Only loading synchronously the smallest amount of CSS needed to render the page. [Load the rest of the CSS asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/).
@@ -36,20 +44,22 @@ CSS and JS resources can be [render blocking](https://developers.google.com/web/
 
 The [critical rendering path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path/analyzing-crp) is made up by the resources that are required in order for the browser to complete rendering the current view. By optimizing the critical rendering path you can improve the time to first render of our pages.
 
-* Study the waterfall and find out which resources are in the critical path. Make them load earlier by using [`rel="dns-prefetch"` and `rel="preconnect"`](https://www.keycdn.com/blog/resource-hints) resource hints as appropriate. Ensure that resources [like CSS](https://web.dev/defer-non-critical-css/) that are _not_ in the critical path are loaded asynchronously or lazy-loaded when possible.
+* Study the waterfall and find out which resources are in the critical path. Make them load earlier by using [`rel="dns-prefetch"` and `rel="preconnect"`](https://www.keycdn.com/blog/resource-hints) resource hints as appropriate.
+* Ensure that resources [like CSS](https://web.dev/defer-non-critical-css/) that are _not_ in the critical path are loaded asynchronously or lazy-loaded when possible.
 
 ## Post launch
 
-* Add the site to [SpeedCurve](https://speedcurve.com) for continuous performance monitoring and alerting. Contact the Frontend Enablement team if you need access to this tool.
+* Add the site to [SpeedCurve](https://speedcurve.com) for continuous performance monitoring and alerting.
 
 ## Tooling
 
 The following tools can be used to run performance tests on one or more pages:
 
-* [Lighthouse](https://developers.google.com/web/tools/lighthouse/): A Google tool that audits pages for performance, accessibility, and others. Available as part of [Chrome's devtools](https://developers.google.com/web/tools/lighthouse/#devtools).
-* [WebPagetest](https://www.webpagetest.org/): The standard tool for synthetic web performance testing.
-* Private WebPage test instance: coming soon.
-* [Speedcurve](https://speedcurve.com/): A tool that automates running tests on WebPagetest and provides graphs, trends, and alerts.
+* [WebPageTest](https://www.webpagetest.org/): The standard tool for synthetic web performance testing.
+* [SpeedCurve](https://speedcurve.com/): A tool that automates running tests on WebPageTest and provides graphs, trends, and alerts.
+* A private WebPageTest instance is available to help with use cases not covered by the two previous tools.
+
+Contact the Frontend Enablement team if you need access to any of these three tools.
 
 ## Further resources
 


### PR DESCRIPTION
- Change advice against using WOFF
- Remove Lighthouse from the list of recommended performance testing tools
- Add bold to the "concatenate files EVEN IF USING HTTP2" bit
- Add links backing up some of the performance-related claims
- Simplify language to help readability
- Make headings use sentence case consistently
- Improve unordered lists formatting
- Add missing TOCs
- Whitespace fixes