### PR TITLE
Improves the RFC2119 statement in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please keep discussion inside the issues and pull requests, avoiding Slack, hall
 
 ## Key words
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this playbook are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP (Best Current Practice) 14](https://www.rfc-editor.org/info/bcp14) ([RFC 2119](https://tools.ietf.org/html/rfc2119), [RFC8174](https://tools.ietf.org/html/rfc8174)) when, and only when, they appear in all capitals, as shown here.
 
 ## License
 


### PR DESCRIPTION
This solves an issue that has been raised in the past about keywords in CAPS rounding rude and unnatural, and also about the uncertainty regarding how these keywords should be interpreted when they are not in caps as a result of the above.

In 2017, RFC8174 was published precisely to deal with this issue. RFC8174 updates RFC2119, and BCP (Best Current Practice) 14 contains both RFC 2119 and RFC 8174.

The new text adds the "NOT RECOMMENDED" keyword and has been taken directly from RFC8174, but I've adapted it slightly for legibility as we are not a standards organisation and I wouldn't necessarily expect all readers to be familiar with BCPs and RFCs (I didn't know myself what a BCP was until half an hour ago!)