### PR TITLE
Updates OSS support documentation

### DIFF
--- a/practices/open-source-support.md
+++ b/practices/open-source-support.md
@@ -18,7 +18,7 @@ Our open source projects are versioned with [SemVer](../git/semver.md). You shou
 To publish a *new* version of one of our open source projects:
 
 * Switch to the default branch. Version commits are the only ones that shouldn't be committed to a feature branch.
-* Consider what type of release this is: `major`, `minor` or `patch` according to SemVer. If you're unsure which, check with the rest of the team or re-read the [SemVer docs](https://semver.org/). Also verify if there are any mentions to the old version in the `README.md` or any other files, and update them too.
+* Consider what type of release this is: `major`, `minor` or `patch` according to SemVer. If you're unsure which, check with the rest of the team or re-read the [SemVer docs](https://semver.org/). Also verify if there are any references to the old version in the `README.md` or any other files, and update them too.
 * Add an entry to the `HISTORY.md` file outlining the changes in the new version. Take your time, this log should be useful to developers who use this project - it should help them make decisions about whether they can or should upgrade. If there are additional commits on the default branch since the last version, be sure to include a description of what they do in your history update - talk to the developers who committed them, if necessary.
 * Run `npm version` depending on the SemVer type of release - e.g. `npm version minor` for a minor release. This will:
   * increment the version in your `package.json`, based on the type of release.


### PR DESCRIPTION
 - recommends use of `npm version ...` convenience function over manual commit and tagging
 - adds `npm publish --dry-run` recommendation(!)
 - updates some links
 - links to SemVer docs
 - updates CI platform recommendation